### PR TITLE
Make HAPI service more suitable for standalone use

### DIFF
--- a/src/main/scala/lasp/hapi/server/HapiServer.scala
+++ b/src/main/scala/lasp/hapi/server/HapiServer.scala
@@ -1,6 +1,5 @@
 package lasp.hapi.server
 
-import scala.concurrent.duration._
 import scala.concurrent.ExecutionContext.Implicits.global
 
 import cats.effect._
@@ -8,59 +7,34 @@ import cats.implicits._
 import fs2.Stream
 import fs2.StreamApp
 import fs2.StreamApp.ExitCode
-import org.http4s._
+import org.http4s.HttpService
 import org.http4s.server.blaze._
-import org.http4s.server.middleware.CORS
-import org.http4s.server.middleware.CORSConfig
 
-import lasp.hapi.service.CapabilitiesService
-import lasp.hapi.service.CatalogService
-import lasp.hapi.service.DataService
 import lasp.hapi.service.HapiService
-import lasp.hapi.service.InfoService
+import lasp.hapi.service.LandingPageService
 
 /**
  * The HAPI server in IO.
  *
  * This is the entry point for the HAPI server.
  */
-object HapiServer extends HapiServerApp[IO] {
-
-  /** Version of HAPI spec. */
-  val version: String = "2.0"
-}
+object HapiServer extends HapiServerApp[IO]
 
 /** The HAPI server parameterized over the effect type. */
 abstract class HapiServerApp[F[_]: Effect] extends StreamApp[F] {
 
-  val corsConfig: CORSConfig = CORSConfig(
-    anyOrigin        = true,
-    anyMethod        = false,
-    allowedMethods   = Set("GET").some,
-    allowedHeaders   = Set("Content-Type").some,
-    allowCredentials = false,
-    maxAge           = 1.day.toSeconds
-  )
+  private val hapiService: HttpService[F] =
+    new HapiService().service
 
-  /** A service composed of all four endpoints. */
-  val endpoints: HttpService[F] = {
-    // If you see a red squiggly here it's probably a lie.
-    val service = {
-      new CapabilitiesService[F].service <+>
-      new InfoService[F].service         <+>
-      new CatalogService[F].service      <+>
-      new DataService[F].service
-    }
-    CORS(service, corsConfig)
-  }
+  private val landingPage: HttpService[F] =
+    new LandingPageService().service
 
-  val landingPage: HttpService[F] =
-    new HapiService[F]().service
+  private val service: HttpService[F] =
+    landingPage <+> hapiService
 
   override def stream(args: List[String], requestShutdown: F[Unit]): Stream[F, ExitCode] =
     BlazeBuilder[F]
       .bindHttp(8080, "0.0.0.0")
-      .mountService(landingPage, "/")
-      .mountService(endpoints, "/hapi/")
+      .mountService(service, "/")
       .serve
 }

--- a/src/main/scala/lasp/hapi/service/CapabilitiesService.scala
+++ b/src/main/scala/lasp/hapi/service/CapabilitiesService.scala
@@ -6,17 +6,15 @@ import org.http4s.HttpService
 import org.http4s.circe._
 import org.http4s.dsl.Http4sDsl
 
-import lasp.hapi.server.HapiServer
-
 /** Implements the `/capabilities` endpoint. */
 class CapabilitiesService[F[_]: Effect] extends Http4sDsl[F] {
 
   val service: HttpService[F] =
     HttpService[F] {
-      case GET -> Root / "capabilities" =>
+      case GET -> Root / "hapi" / "capabilities" =>
         Ok(
           Capabilities(
-            HapiServer.version,
+            HapiService.version,
             Status.`1200`,
             List("binary", "csv", "json")
           ).asJson

--- a/src/main/scala/lasp/hapi/service/CatalogService.scala
+++ b/src/main/scala/lasp/hapi/service/CatalogService.scala
@@ -9,7 +9,7 @@ class CatalogService[F[_]: Effect] extends Http4sDsl[F] {
 
   val service: HttpService[F] =
     HttpService[F] {
-      case GET -> Root / "catalog" =>
+      case GET -> Root / "hapi" / "catalog" =>
         Ok("Hello from HAPI!")
     }
 }

--- a/src/main/scala/lasp/hapi/service/DataService.scala
+++ b/src/main/scala/lasp/hapi/service/DataService.scala
@@ -14,7 +14,7 @@ class DataService[F[_]: Effect] extends Http4sDsl[F] {
 
   val service: HttpService[F] =
     HttpService[F] {
-      case GET -> Root / "data"
+      case GET -> Root / "hapi" / "data"
           :? IdMatcher(_)
           +& MinTimeMatcher(_)
           +& MaxTimeMatcher(_)
@@ -23,7 +23,7 @@ class DataService[F[_]: Effect] extends Http4sDsl[F] {
           +& FormatMatcher(_) =>
         Ok("Hello from HAPI!")
       // Return a 1400 error if the required parameters are not given.
-      case GET -> Root / "data" :? _ =>
+      case GET -> Root / "hapi" / "data" :? _ =>
         BadRequest(Status.`1400`.asJson)
     }
 }

--- a/src/main/scala/lasp/hapi/service/HapiService.scala
+++ b/src/main/scala/lasp/hapi/service/HapiService.scala
@@ -1,50 +1,53 @@
 package lasp.hapi.service
 
+import scala.concurrent.duration._
+
 import cats.effect.Effect
 import cats.implicits._
 import org.http4s.HttpService
-import org.http4s.MediaType.`text/html`
-import org.http4s.dsl.Http4sDsl
-import org.http4s.headers.`Content-Type`
-import scalatags.Text.all._
+import org.http4s.server.middleware.CORS
+import org.http4s.server.middleware.CORSConfig
 
-/** Implements the `/hapi` endpoint. */
-class HapiService[F[_]: Effect] extends Http4sDsl[F] {
+/**
+ * A grouping of all four required HAPI endpoints.
+ *
+ * The HAPI spec defines four required endpoints. This class groups
+ * those four endpoints and exposes them as a single service that
+ * implements the HAPI spec.
+ *
+ * These are the routes for each service:
+ *
+ *  - `/hapi/capabilities`
+ *  - `/hapi/catalog`
+ *  - `/hapi/data`
+ *  - `/hapi/info`
+ */
+class HapiService[F[_]: Effect] {
 
-  val landingPage: Frag =
-    html(
-      body(
-        h1("LASP HAPI Server"),
-        p("""This server supports the HAPI 2.0 specification for
-        |delivery of time series data. The server consists of the
-        |following 4 REST-like endpoints that will respond to HTTP GET
-        |requests:""".stripMargin.replaceAll("\n", " ")),
-        ul(
-          li(
-            a(href := "hapi/capabilities")("capabilities"),
-            " - list the output formats the server can emit"
-          ),
-          li(
-            a(href := "hapi/catalog")("catalog"),
-            " - list the datasets that are available"
-          ),
-          li(
-            a(href := "hapi/info")("info"),
-            " - describe a dataset"
-          ),
-          li(
-            a(href := "hapi/data")("data"),
-            " - stream content of a dataset"
-          )
-        )
-      )
-    )
+  private val corsConfig: CORSConfig = CORSConfig(
+    anyOrigin        = true,
+    anyMethod        = false,
+    allowedMethods   = Set("GET").some,
+    allowedHeaders   = Set("Content-Type").some,
+    allowCredentials = false,
+    maxAge           = 1.day.toSeconds
+  )
 
-  val service: HttpService[F] =
-    HttpService[F] {
-      case GET -> Root / "hapi" =>
-        Ok(landingPage.render).map {
-          _.withContentType(`Content-Type`(`text/html`))
-        }
+  /** A service composed of all four required HAPI endpoints. */
+  val service: HttpService[F] = {
+    // If you see a red squiggly here it's probably a lie.
+    val service = {
+      new CapabilitiesService[F].service <+>
+      new InfoService[F].service         <+>
+      new CatalogService[F].service      <+>
+      new DataService[F].service
     }
+    CORS(service, corsConfig)
+  }
+}
+
+object HapiService {
+
+  /** Version of HAPI spec. */
+  val version: String = "2.0"
 }

--- a/src/main/scala/lasp/hapi/service/InfoService.scala
+++ b/src/main/scala/lasp/hapi/service/InfoService.scala
@@ -12,12 +12,12 @@ class InfoService[F[_]: Effect] extends Http4sDsl[F] {
 
   val service: HttpService[F] =
     HttpService[F] {
-      case GET -> Root / "info"
+      case GET -> Root / "hapi" / "info"
           :? IdMatcher(_)
           +& ParamMatcher(_) =>
         Ok("Hello from HAPI!")
       // Return a 1400 error if the required parameters are not given.
-      case GET -> Root / "info" :? _ =>
+      case GET -> Root / "hapi" / "info" :? _ =>
         BadRequest(Status.`1400`.asJson)
     }
 }

--- a/src/main/scala/lasp/hapi/service/LandingPageService.scala
+++ b/src/main/scala/lasp/hapi/service/LandingPageService.scala
@@ -1,0 +1,50 @@
+package lasp.hapi.service
+
+import cats.effect.Effect
+import cats.implicits._
+import org.http4s.HttpService
+import org.http4s.MediaType.`text/html`
+import org.http4s.dsl.Http4sDsl
+import org.http4s.headers.`Content-Type`
+import scalatags.Text.all._
+
+/** Implements the HAPI landing page. */
+class LandingPageService[F[_]: Effect] extends Http4sDsl[F] {
+
+  val landingPage: Frag =
+    html(
+      body(
+        h1("LASP HAPI Server"),
+        p("""This server supports the HAPI 2.0 specification for
+        |delivery of time series data. The server consists of the
+        |following 4 REST-like endpoints that will respond to HTTP GET
+        |requests:""".stripMargin.replaceAll("\n", " ")),
+        ul(
+          li(
+            a(href := "hapi/capabilities")("capabilities"),
+            " - list the output formats the server can emit"
+          ),
+          li(
+            a(href := "hapi/catalog")("catalog"),
+            " - list the datasets that are available"
+          ),
+          li(
+            a(href := "hapi/info")("info"),
+            " - describe a dataset"
+          ),
+          li(
+            a(href := "hapi/data")("data"),
+            " - stream content of a dataset"
+          )
+        )
+      )
+    )
+
+  val service: HttpService[F] =
+    HttpService[F] {
+      case GET -> Root / "hapi" =>
+        Ok(landingPage.render).map {
+          _.withContentType(`Content-Type`(`text/html`))
+        }
+    }
+}

--- a/src/test/scala/lasp/hapi/service/CapabilitiesServiceSpec.scala
+++ b/src/test/scala/lasp/hapi/service/CapabilitiesServiceSpec.scala
@@ -7,15 +7,13 @@ import org.http4s._
 import org.http4s.implicits._
 import org.scalatest.FlatSpec
 
-import lasp.hapi.server.HapiServer
-
 class CapabilitiesServiceSpec extends FlatSpec {
 
   "The capabilities service" should "advertise all output options" in {
-    val req = Request[IO](Method.GET, Uri.uri("/capabilities"))
+    val req = Request[IO](Method.GET, Uri.uri("/hapi/capabilities"))
 
     val expected = Json.obj(
-      ("HAPI", Json.fromString(HapiServer.version)),
+      ("HAPI", Json.fromString(HapiService.version)),
       ("status", Status.`1200`.asJson),
       ("outputFormats", Json.fromValues(
         List(


### PR DESCRIPTION
Stuff in `lasp.hapi.service` will eventually become its own project that can be used in other projects, and this is the first step towards that.

`HapiService` is intended to be a self-contained HAPI service that has the four HAPI endpoints properly routed and configured. Ideally, one could create an instance of `HapiService` and `mount` it in their server (with the proper configuration) to add a HAPI service to their server.

Prior to these changes, the routing and configuration was handled by `HapiServer` (the implementation of this specific standalone HAPI server) even though any server providing a HAPI service would need to do the same things.