### PR TITLE
Add HAPI time string parser

### DIFF
--- a/src/main/scala/lasp/hapi/util/Time.scala
+++ b/src/main/scala/lasp/hapi/util/Time.scala
@@ -1,0 +1,55 @@
+package lasp.hapi.util
+
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+import java.time.format.DateTimeFormatterBuilder
+import java.time.format.DateTimeParseException
+import java.time.temporal.ChronoField.DAY_OF_MONTH
+import java.time.temporal.ChronoField.HOUR_OF_DAY
+import java.time.temporal.ChronoField.MINUTE_OF_HOUR
+import java.time.temporal.ChronoField.MONTH_OF_YEAR
+import java.time.temporal.ChronoField.NANO_OF_SECOND
+import java.time.temporal.ChronoField.SECOND_OF_MINUTE
+
+/** Time utilties. */
+object Time {
+
+  /**
+   * Parses a HAPI time string.
+   *
+   * @param str HAPI time string
+   */
+  def parse(str: String): Option[LocalDateTime] =
+    tryParse(str, format) orElse tryParse(str, formatOrd)
+
+  private def tryParse(str: String, fmt: DateTimeFormatter): Option[LocalDateTime] =
+    try {
+      Option(LocalDateTime.parse(str, fmt))
+    } catch {
+      case _: DateTimeParseException => None
+    }
+
+  /** Format for normal date/time strings. */
+  private val format: DateTimeFormatter =
+    new DateTimeFormatterBuilder()
+      .appendPattern("yyyy[-MM[-dd['T'HH[:mm[:ss[.SSS]]]]]]['Z']")
+      .parseDefaulting(MONTH_OF_YEAR, 1)
+      .parseDefaulting(DAY_OF_MONTH, 1)
+      .parseDefaulting(HOUR_OF_DAY, 0)
+      .parseDefaulting(MINUTE_OF_HOUR, 0)
+      .parseDefaulting(SECOND_OF_MINUTE, 0)
+      .parseDefaulting(NANO_OF_SECOND, 0)
+      .toFormatter()
+
+  /** Format for ordinal date/time strings. */
+  private val formatOrd: DateTimeFormatter =
+    new DateTimeFormatterBuilder()
+      .appendPattern("yyyy[-DDD['T'HH[:mm[:ss[.SSS]]]]]['Z']")
+      .parseDefaulting(MONTH_OF_YEAR, 1)
+      .parseDefaulting(DAY_OF_MONTH, 1)
+      .parseDefaulting(HOUR_OF_DAY, 0)
+      .parseDefaulting(MINUTE_OF_HOUR, 0)
+      .parseDefaulting(SECOND_OF_MINUTE, 0)
+      .parseDefaulting(NANO_OF_SECOND, 0)
+      .toFormatter()
+}

--- a/src/test/scala/lasp/hapi/util/TimeSpec.scala
+++ b/src/test/scala/lasp/hapi/util/TimeSpec.scala
@@ -1,0 +1,80 @@
+package lasp.hapi.util
+
+import java.time.LocalDateTime
+
+import org.scalactic.Equality
+import org.scalatest.Assertion
+import org.scalatest.FlatSpec
+
+class TimeSpec extends FlatSpec {
+
+  val expected = LocalDateTime.of(2018, 1, 1, 0, 0, 0)
+
+  def testParse(str: String): Assertion =
+    assert {
+      expected === Time.parse(str).getOrElse {
+        fail(s"Failed to parse time string: $str")
+      }
+    }
+
+  // The `equals` method should be used to compare `LocalDateTime`
+  // instances. See the Javadocs.
+  implicit val eq: Equality[LocalDateTime] =
+    new Equality[LocalDateTime] {
+      override def areEqual(a: LocalDateTime, b: Any): Boolean = a.equals(b)
+    }
+
+  "The time string parser" should "parse date and time strings" in {
+    testParse("2018-01-01T00:00:00.000Z")
+
+    // Missing the trailing 'Z'
+    testParse("2018-01-01T00:00:00.000")
+  }
+
+  it should "parse ordinal date and time strings" in {
+    testParse("2018-001T00:00:00Z")
+
+    // Missing the trailing 'Z'
+    testParse("2018-001T00:00:00")
+  }
+
+  it should "parse date strings" in {
+    testParse("2018-01-01Z")
+
+    // Missing the trailing 'Z'
+    testParse("2018-01-01")
+  }
+
+  it should "parse ordinal date strings" in {
+    testParse("2018-001Z")
+
+    // Missing the trailing 'Z'
+    testParse("2018-001")
+  }
+
+  it should "handle missing date or time elements" in {
+    // No milliseconds
+    testParse("2018-01-01T00:00:00")
+
+    // No milliseconds (ordinal date)
+    testParse("2018-001T00:00:00")
+
+    // No seconds
+    testParse("2018-01-01T00:00Z")
+
+    // No seconds (ordinal date)
+    testParse("2018-001T00:00Z")
+
+    // No minutes
+    testParse("2018-01-01T00Z")
+
+    // No minutes (ordinal date)
+    testParse("2018-001T00Z")
+
+    // No day of month
+    testParse("2018-01Z")
+
+    // No month
+    testParse("2018Z")
+  }
+}


### PR DESCRIPTION
This uses the `java.time` API to parse HAPI time strings.

See [Representation of Time](https://github.com/hapi-server/data-specification/blob/master/hapi-2.0.0/HAPI-data-access-spec-2.0.0.md#representation-of-time) in the HAPI spec.

See #26.