### PR TITLE
Construct DataRequest object from query

### DIFF
--- a/src/main/scala/lasp/hapi/service/DataRequest.scala
+++ b/src/main/scala/lasp/hapi/service/DataRequest.scala
@@ -1,5 +1,7 @@
 package lasp.hapi.service
 
+import java.time.LocalDateTime
+
 /**
  * Represents a request for data.
  *
@@ -12,8 +14,8 @@ package lasp.hapi.service
  */
 final case class DataRequest(
   id: String,
-  minTime: String,
-  maxTime: String,
+  minTime: LocalDateTime,
+  maxTime: LocalDateTime,
   parameters: Option[List[String]],
   header: Boolean,
   format: String

--- a/src/main/scala/lasp/hapi/service/DataService.scala
+++ b/src/main/scala/lasp/hapi/service/DataService.scala
@@ -1,6 +1,7 @@
 package lasp.hapi.service
 
 import cats.effect.Effect
+import cats.implicits._
 import io.circe.syntax._
 import org.http4s.HttpService
 import org.http4s.circe._
@@ -15,13 +16,27 @@ class DataService[F[_]: Effect] extends Http4sDsl[F] {
   val service: HttpService[F] =
     HttpService[F] {
       case GET -> Root / "hapi" / "data"
-          :? IdMatcher(_)
-          +& MinTimeMatcher(_)
-          +& MaxTimeMatcher(_)
-          +& ParamMatcher(_)
-          +& IncludeMatcher(_)
-          +& FormatMatcher(_) =>
-        Ok("Hello from HAPI!")
+          :? IdMatcher(_id)
+          +& MinTimeMatcher(_minTime)
+          +& MaxTimeMatcher(_maxTime)
+          +& ParamMatcher(_params)
+          +& IncludeMatcher(_inc)
+          +& FormatMatcher(_fmt) =>
+        val req: Either[Status, DataRequest] =
+          for {
+            id      <- _id.asRight
+            minTime <- _minTime.leftMap(_ => Status.`1402`).toEither
+            maxTime <- _maxTime.leftMap(_ => Status.`1403`).toEither
+            _       <- Either.cond(minTime.isBefore(maxTime), (), Status.`1404`)
+            params  <- _params.asRight
+            inc     <- _inc.getOrElse(Include(false).validNel).bimap(
+              _ => Status.`1410`, _.header
+            ).toEither
+            fmt     <- _fmt.getOrElse(Format("csv").validNel).bimap(
+              _ => Status.`1409`, _.format
+            ).toEither
+          } yield DataRequest(id, minTime, maxTime, params, inc, fmt)
+        req.fold(err => BadRequest(err.asJson), _ => Ok("Hello from HAPI!"))
       // Return a 1400 error if the required parameters are not given.
       case GET -> Root / "hapi" / "data" :? _ =>
         BadRequest(Status.`1400`.asJson)

--- a/src/main/scala/lasp/hapi/service/Format.scala
+++ b/src/main/scala/lasp/hapi/service/Format.scala
@@ -23,5 +23,5 @@ object Format {
       }
     }
 
-  object FormatMatcher extends OptionalQueryParamDecoderMatcher[Format]("format")
+  object FormatMatcher extends OptionalValidatingQueryParamDecoderMatcher[Format]("format")
 }

--- a/src/main/scala/lasp/hapi/service/Include.scala
+++ b/src/main/scala/lasp/hapi/service/Include.scala
@@ -23,5 +23,5 @@ object Include {
       }
     }
 
-  object IncludeMatcher extends OptionalQueryParamDecoderMatcher[Include]("include")
+  object IncludeMatcher extends OptionalValidatingQueryParamDecoderMatcher[Include]("include")
 }


### PR DESCRIPTION
I've used the parser added in #33 to validate time strings given in queries. As I wrote the code to do the validation, I figured I might as well do the whole thing, so now the entire query is validated and we actually end up constructing the `DataRequest` object that will eventually be used to construct a response.

Here's where we are now:

- If the query is invalid, we return the appropriate HAPI status.
    - See the tests for examples of this.
- If the query is valid, we construct the `DataRequest` object, throw it away, and give the `"Hello from HAPI!"` response.

Resolves #26 and resolves #28.