### PR TITLE
Read a LaTiS 2 catalog

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,6 +5,7 @@ val http4sVersion = "0.18.15"
 
 lazy val `hapi-server` = (project in file("."))
   .enablePlugins(DockerPlugin)
+  .dependsOn(latis2)
   .settings(compilerFlags)
   .settings(dockerSettings)
   .settings(
@@ -18,6 +19,11 @@ lazy val `hapi-server` = (project in file("."))
     ),
     Test / logBuffered := false
   )
+
+lazy val latis2 = ProjectRef(
+  uri("git://github.com/latis-data/latis.git#78e60aeb5387a047ceb99db56a1bd49786100904"),
+  "latis"
+)
 
 lazy val compilerFlags = Seq(
   scalacOptions ++= Seq(

--- a/src/main/scala/lasp/hapi/server/HapiServer.scala
+++ b/src/main/scala/lasp/hapi/server/HapiServer.scala
@@ -10,6 +10,7 @@ import fs2.StreamApp.ExitCode
 import org.http4s.HttpService
 import org.http4s.server.blaze._
 
+import lasp.hapi.service.HapiInterpreter
 import lasp.hapi.service.HapiService
 import lasp.hapi.service.LandingPageService
 
@@ -24,7 +25,7 @@ object HapiServer extends HapiServerApp[IO]
 abstract class HapiServerApp[F[_]: Effect] extends StreamApp[F] {
 
   private val hapiService: HttpService[F] =
-    new HapiService().service
+    new HapiService(HapiInterpreter.noopInterpreter[F]).service
 
   private val landingPage: HttpService[F] =
     new LandingPageService().service

--- a/src/main/scala/lasp/hapi/service/CatalogAlgebra.scala
+++ b/src/main/scala/lasp/hapi/service/CatalogAlgebra.scala
@@ -1,0 +1,8 @@
+package lasp.hapi.service
+
+/** Algebra of catalog operations. */
+trait CatalogAlgebra[F[_]] {
+
+  /** Get the catalog of datasets. */
+  val getCatalog: F[List[Dataset]]
+}

--- a/src/main/scala/lasp/hapi/service/CatalogService.scala
+++ b/src/main/scala/lasp/hapi/service/CatalogService.scala
@@ -1,15 +1,29 @@
 package lasp.hapi.service
 
 import cats.effect.Effect
+import cats.implicits._
+import io.circe.syntax._
 import org.http4s.HttpService
+import org.http4s.circe._
 import org.http4s.dsl.Http4sDsl
 
-/** Implements the `/catalog` endpoint. */
-class CatalogService[F[_]: Effect] extends Http4sDsl[F] {
+/**
+ * Implements the `/catalog` endpoint.
+ *
+ * @constructor Create a `CatalogService` with an interpreter for the
+ *              catalog algebra.
+ * @param alg interpreter for catalog algebra
+ */
+class CatalogService[F[_]: Effect](alg: CatalogAlgebra[F]) extends Http4sDsl[F] {
 
   val service: HttpService[F] =
     HttpService[F] {
       case GET -> Root / "hapi" / "catalog" =>
-        Ok("Hello from HAPI!")
+        val res = for {
+          version <- HapiService.version.pure[F]
+          status  <- Status.`1200`.pure[F]
+          catalog <- alg.getCatalog
+        } yield Catalog(version, status, catalog)
+        res.flatMap(catalog => Ok(catalog.asJson))
     }
 }

--- a/src/main/scala/lasp/hapi/service/HapiInterpreter.scala
+++ b/src/main/scala/lasp/hapi/service/HapiInterpreter.scala
@@ -1,0 +1,17 @@
+package lasp.hapi.service
+
+import cats.Applicative
+import cats.implicits._
+
+/** Interpreter for the algebras making up the HAPI services. */
+trait HapiInterpreter[F[_]] extends CatalogAlgebra[F]
+
+object HapiInterpreter {
+
+  /** Interpreter that does nothing. */
+  def noopInterpreter[F[_]: Applicative]: HapiInterpreter[F] =
+    new HapiInterpreter[F] {
+      override val getCatalog: F[List[Dataset]] =
+        List.empty[Dataset].pure[F]
+    }
+}

--- a/src/main/scala/lasp/hapi/service/HapiService.scala
+++ b/src/main/scala/lasp/hapi/service/HapiService.scala
@@ -21,8 +21,11 @@ import org.http4s.server.middleware.CORSConfig
  *  - `/hapi/catalog`
  *  - `/hapi/data`
  *  - `/hapi/info`
+ *
+ * @constructor Create a HAPI service with the given interpreter.
+ * @param interpreter interpreter for HAPI algebras
  */
-class HapiService[F[_]: Effect] {
+class HapiService[F[_]: Effect](interpreter: HapiInterpreter[F]) {
 
   private val corsConfig: CORSConfig = CORSConfig(
     anyOrigin        = true,
@@ -37,9 +40,9 @@ class HapiService[F[_]: Effect] {
   val service: HttpService[F] = {
     // If you see a red squiggly here it's probably a lie.
     val service = {
-      new CapabilitiesService[F].service <+>
-      new InfoService[F].service         <+>
-      new CatalogService[F].service      <+>
+      new CapabilitiesService[F].service         <+>
+      new InfoService[F].service                 <+>
+      new CatalogService[F](interpreter).service <+>
       new DataService[F].service
     }
     CORS(service, corsConfig)

--- a/src/main/scala/lasp/hapi/service/latis2/Latis2Interpreter.scala
+++ b/src/main/scala/lasp/hapi/service/latis2/Latis2Interpreter.scala
@@ -1,0 +1,31 @@
+package lasp.hapi.service
+package latis2
+
+import cats.effect.Sync
+import latis.dm
+import latis.dm.{ Dataset => _, _ }
+import latis.reader.CatalogReader
+
+/**
+ * Interpreter for HAPI algebras using LaTiS 2.
+ *
+ * @constructor Create an interpreter that reads the catalog from the
+ *              given directory.
+ * @param dir directory that is the root of the catalog
+ */
+class Latis2Interpreter[F[_]: Sync](dir: String) extends HapiInterpreter[F] {
+
+  override val getCatalog: F[List[Dataset]] =
+    Sync[F].delay {
+      new CatalogReader(dir).getDataset() match {
+        case dm.Dataset(Function(it)) =>
+          it.flatMap {
+            case Sample(_, Function(it)) =>
+              it.map {
+                case Sample(Text(name), _) =>
+                  Dataset(name)
+              }
+          }.toList
+      }
+    }
+}


### PR DESCRIPTION
**Overview of changes**

- Add a source dependency on LaTiS 2.
    - We are depending on a particular commit from LaTiS 2 on GitHub.
    - After the tag for the next release is pushed I'll update the commit here to point to that tag. Ideally we'll just depend on tagged releases of LaTiS 2.
- Define `CatalogAlgebra`.
    - This is an algebra in the [tagless final](https://www.beyondthelines.net/programming/introduction-to-tagless-final/) sense.
    - In short, `CatalogAlgebra` is a typeclass that defines the operations one can do to the catalog. In our case, the only operation is to get the catalog.
    - "Interpreters" of this algebra implement the operation.
- Implement the `catalog` endpoint in terms of `CatalogAlgebra`.
    - Rather than relying on a concrete implementation, we can rely on the abstract operations provided by the algebra and let the interpreters decide what actually gets done.
- Define `HapiInterpreter`.
    - This is intended to be the trait that all interpreters (LaTiS 2, LaTiS 3, something else) extend.
    - Right now there is only the catalog algebra, but this will include algebras for the other endpoints as they are added.
- Construct `HapiService` with `HapiInterpreter`, construct `CatalogService` with a `CatalogAlgebra` (the interpreter for the catalog algebra).
    - In order to construct working instances of these things you need to provide the interpreter you want to use.
    - The default is to use a no-op interpreter that currently returns an empty catalog.
- Add `Latis2Interpreter`.
    - This implements the catalog algebra using LaTiS 2's `CatalogReader`.
    - If you swap the no-op interpreter for this one, you can read TSML from your local file system and get a catalog.

Closes #7.