### PR TITLE
Implement data response

### DIFF
--- a/src/main/scala/lasp/hapi/service/CapabilitiesService.scala
+++ b/src/main/scala/lasp/hapi/service/CapabilitiesService.scala
@@ -16,7 +16,7 @@ class CapabilitiesService[F[_]: Effect] extends Http4sDsl[F] {
           Capabilities(
             HapiService.version,
             Status.`1200`,
-            List("binary", "csv", "json")
+            List("csv")
           ).asJson
         )
     }

--- a/src/main/scala/lasp/hapi/service/DataAlgebra.scala
+++ b/src/main/scala/lasp/hapi/service/DataAlgebra.scala
@@ -1,0 +1,25 @@
+package lasp.hapi.service
+
+import fs2.Stream
+
+/** Algebra for reading data. */
+trait DataAlgebra[F[_]] {
+
+  /** Type of data read by algebra. */
+  type T
+
+  /**
+   * Read data given a request.
+   *
+   * @param req request information
+   */
+  def getData(req: DataRequest): F[T]
+
+  /**
+   * Write data as CSV.
+   *
+   * @param data data to write
+   * @return a stream of CSV records
+   */
+  def writeData(data: T): Stream[F, String]
+}

--- a/src/main/scala/lasp/hapi/service/Format.scala
+++ b/src/main/scala/lasp/hapi/service/Format.scala
@@ -14,7 +14,7 @@ object Format {
   implicit val formatDecoder: QueryParamDecoder[Format] =
     new QueryParamDecoder[Format] {
       override def decode(qpv: QueryParameterValue) = qpv.value match {
-        case fmt @ ("csv" | "binary" | "json") => Format(fmt).validNel
+        case fmt @ "csv" => Format(fmt).validNel
         case _ =>
           ParseFailure(
             "Invalid value for 'format' parameter",

--- a/src/main/scala/lasp/hapi/service/HapiInterpreter.scala
+++ b/src/main/scala/lasp/hapi/service/HapiInterpreter.scala
@@ -4,15 +4,22 @@ import cats.Applicative
 import cats.data.EitherT
 import cats.data.NonEmptyList
 import cats.implicits._
+import fs2.Stream
 
 /** Interpreter for the algebras making up the HAPI services. */
-trait HapiInterpreter[F[_]] extends CatalogAlgebra[F] with InfoAlgebra[F]
+trait HapiInterpreter[F[_]]
+    extends CatalogAlgebra[F]
+    with DataAlgebra[F]
+    with InfoAlgebra[F]
 
 object HapiInterpreter {
 
   /** Interpreter that does nothing. */
   def noopInterpreter[F[_]: Applicative]: HapiInterpreter[F] =
     new HapiInterpreter[F] {
+
+      type T = Unit
+
       override val getCatalog: F[List[Dataset]] =
         List.empty[Dataset].pure[F]
 
@@ -21,5 +28,11 @@ object HapiInterpreter {
         params: Option[NonEmptyList[String]]
       ): EitherT[F, InfoError, Metadata] =
         EitherT.leftT(UnknownId(""))
+
+      override def getData(req: DataRequest): F[Unit] =
+        ().pure[F]
+
+      override def writeData(data: Unit): Stream[F, String] =
+        Stream.empty
     }
 }

--- a/src/main/scala/lasp/hapi/service/HapiService.scala
+++ b/src/main/scala/lasp/hapi/service/HapiService.scala
@@ -43,7 +43,7 @@ class HapiService[F[_]: Effect](interpreter: HapiInterpreter[F]) {
       new CapabilitiesService[F].service         <+>
       new InfoService[F](interpreter).service    <+>
       new CatalogService[F](interpreter).service <+>
-      new DataService[F].service
+      new DataService[F](interpreter).service
     }
     CORS(service, corsConfig)
   }

--- a/src/main/scala/lasp/hapi/service/Parameter.scala
+++ b/src/main/scala/lasp/hapi/service/Parameter.scala
@@ -17,9 +17,9 @@ import io.circe.Encoder
 final case class Parameter(
   name: String,
   dType: DataType,
-  length: Option[Integer],
+  length: Option[Int],
   units: String,
-  size: Option[List[Integer]],
+  size: Option[List[Int]],
   fill: Option[String],
   description: Option[String],
   bins: Option[List[Bin]]

--- a/src/main/scala/lasp/hapi/service/latis2/Latis2Interpreter.scala
+++ b/src/main/scala/lasp/hapi/service/latis2/Latis2Interpreter.scala
@@ -68,7 +68,7 @@ class Latis2Interpreter[F[_]: Sync] extends HapiInterpreter[F] {
       val ops = List(
         Selection(s"time>=${minTime.format(Time.format)}"),
         Selection(s"time<${maxTime.format(Time.format)}"),
-        TimeFormatter("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
+        TimeFormatter(Time.formatSDF)
       ) ++ params.fold(
         List.empty[Operation]
       )(

--- a/src/main/scala/lasp/hapi/service/latis2/Latis2Util.scala
+++ b/src/main/scala/lasp/hapi/service/latis2/Latis2Util.scala
@@ -7,6 +7,9 @@ import cats.implicits._
 import latis.dm._
 import latis.ops.Operation
 import latis.reader.DatasetAccessor
+import latis.time.Time
+
+import lasp.hapi.util
 
 /** Utility methods for working with LaTiS 2. */
 object Latis2Util {
@@ -50,6 +53,8 @@ object Latis2Util {
           for {
             tParam <- getParameterMetadata(tVar)
             timeMd  = tVar.getMetadata
+            tMin   <- convertTime(timeMd.get("min").get)
+            tMax   <- convertTime(timeMd.get("max").get)
             // We are assuming no nested functions. We also need to
             // check that a scalar range variables isn't time so we
             // don't include it twice. (See above.)
@@ -63,8 +68,8 @@ object Latis2Util {
             }
           } yield Metadata(
             NonEmptyList(tParam, params),
-            timeMd.get("min").get,
-            timeMd.get("max").get,
+            tMin,
+            tMax,
             None,
             None,
             None,
@@ -130,5 +135,11 @@ object Latis2Util {
             None
           )
       }
+    }
+
+  /** Convert a time of a given scale to a HAPI time string. */
+  private def convertTime[F[_]: Sync](time: String): F[String] =
+    Sync[F].delay {
+      Time.fromIso(time).format(util.Time.formatSDF)
     }
 }

--- a/src/main/scala/lasp/hapi/service/latis2/Latis2Util.scala
+++ b/src/main/scala/lasp/hapi/service/latis2/Latis2Util.scala
@@ -89,9 +89,7 @@ object Latis2Util {
           Parameter(
             "time",
             HIsoTime,
-            // This will only be correct if the time is already a HAPI
-            // time string.
-            md.get("length").map(_.toInt),
+            Option(24),
             "UTC",
             None,
             None,

--- a/src/main/scala/lasp/hapi/util/Time.scala
+++ b/src/main/scala/lasp/hapi/util/Time.scala
@@ -30,7 +30,7 @@ object Time {
     }
 
   /** Format for normal date/time strings. */
-  private val format: DateTimeFormatter =
+  val format: DateTimeFormatter =
     new DateTimeFormatterBuilder()
       .appendPattern("yyyy[-MM[-dd['T'HH[:mm[:ss[.SSS]]]]]]['Z']")
       .parseDefaulting(MONTH_OF_YEAR, 1)
@@ -42,7 +42,7 @@ object Time {
       .toFormatter()
 
   /** Format for ordinal date/time strings. */
-  private val formatOrd: DateTimeFormatter =
+  val formatOrd: DateTimeFormatter =
     new DateTimeFormatterBuilder()
       .appendPattern("yyyy[-DDD['T'HH[:mm[:ss[.SSS]]]]]['Z']")
       .parseDefaulting(MONTH_OF_YEAR, 1)

--- a/src/main/scala/lasp/hapi/util/Time.scala
+++ b/src/main/scala/lasp/hapi/util/Time.scala
@@ -41,6 +41,10 @@ object Time {
       .parseDefaulting(NANO_OF_SECOND, 0)
       .toFormatter()
 
+  /** Format as `SimpleDateFormat` string. */
+  val formatSDF: String =
+    "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"
+
   /** Format for ordinal date/time strings. */
   val formatOrd: DateTimeFormatter =
     new DateTimeFormatterBuilder()

--- a/src/test/scala/lasp/hapi/service/CapabilitiesServiceSpec.scala
+++ b/src/test/scala/lasp/hapi/service/CapabilitiesServiceSpec.scala
@@ -9,7 +9,7 @@ import org.scalatest.FlatSpec
 
 class CapabilitiesServiceSpec extends FlatSpec {
 
-  "The capabilities service" should "advertise all output options" in {
+  "The capabilities service" should "advertise CSV only" in {
     val req = Request[IO](Method.GET, Uri.uri("/hapi/capabilities"))
 
     val expected = Json.obj(
@@ -17,9 +17,7 @@ class CapabilitiesServiceSpec extends FlatSpec {
       ("status", Status.`1200`.asJson),
       ("outputFormats", Json.fromValues(
         List(
-          Json.fromString("binary"),
-          Json.fromString("csv"),
-          Json.fromString("json")
+          Json.fromString("csv")
         )
       ))
     )

--- a/src/test/scala/lasp/hapi/service/DataServiceSpec.scala
+++ b/src/test/scala/lasp/hapi/service/DataServiceSpec.scala
@@ -74,17 +74,17 @@ class DataServiceSpec extends FlatSpec {
     decoded.fold(_ => fail, x => assert(x.format == fmt))
   }
 
-  it should "accept 'binary'" in {
-    val fmt = "binary"
-    val decoded = Format.formatDecoder.decode(QueryParameterValue(fmt))
-    decoded.fold(_ => fail, x => assert(x.format == fmt))
-  }
+  // it should "accept 'binary'" in {
+  //   val fmt = "binary"
+  //   val decoded = Format.formatDecoder.decode(QueryParameterValue(fmt))
+  //   decoded.fold(_ => fail, x => assert(x.format == fmt))
+  // }
 
-  it should "accept 'json'" in {
-    val fmt = "json"
-    val decoded = Format.formatDecoder.decode(QueryParameterValue(fmt))
-    decoded.fold(_ => fail, x => assert(x.format == fmt))
-  }
+  // it should "accept 'json'" in {
+  //   val fmt = "json"
+  //   val decoded = Format.formatDecoder.decode(QueryParameterValue(fmt))
+  //   decoded.fold(_ => fail, x => assert(x.format == fmt))
+  // }
 
   it should "reject other arguments" in {
     val decoded = Format.formatDecoder.decode(QueryParameterValue("yolo"))

--- a/src/test/scala/lasp/hapi/service/DataServiceSpec.scala
+++ b/src/test/scala/lasp/hapi/service/DataServiceSpec.scala
@@ -9,11 +9,13 @@ import org.http4s.implicits._
 import org.scalatest.Assertion
 import org.scalatest.FlatSpec
 
+import lasp.hapi.service.HapiInterpreter.noopInterpreter
+
 class DataServiceSpec extends FlatSpec {
 
   /** Assert GET request to given URI returns a particular status. */
   def assertStatus(uri: Uri, status: Status): Assertion = {
-    val service = new DataService[IO].service
+    val service = new DataService[IO](noopInterpreter).service
     val req = Request[IO](Method.GET, uri)
 
     val body = service.orNotFound(req).flatMap { res =>


### PR DESCRIPTION
These commits add the algebra and interpreters for `data` requests.

In particular, look at how I implemented the algebra in `Latis2Interpreter` and let me know if there's a better way to do the things I've done. I'll need to revisit later and work on patching things up so we return useful errors when things go wrong on the LaTiS side.

I believe the same limitations that applied to `info` requests (#10, #39) apply here.

I've restricted the output to CSV only (the minimum required) to make life easier for now. I've also just implemented a really dumb CSV writer because the dataset shapes we're supporting now are simple.

Closes #11.