### PR TITLE
Set up configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,22 @@ A [HAPI][hapi] server built on LaTiS.
 
 [hapi]: https://hapi-server.github.io/
 
+## Configuration
+
+There are two methods for configuring the HAPI server:
+
+1. [HOCON][hocon] configuration file
+2. Environment variables
+
+### Configuration Options
+
+| Configuration key | Environment variable | Description                  | Default          |
+| ----------------- | -------------------- | ---------------------------- | ---------------- |
+| `port`            | `HAPI_PORT`          | Port to listen on            | 8080             |
+| `mapping`         | `HAPI_MAPPING`       | URL segment before `/hapi`   | "/"              |
+
+[hocon]: https://github.com/lightbend/config/blob/master/HOCON.md
+
 ## Running with Docker
 
 The `docker` SBT task will build a Docker image. The Docker daemon
@@ -15,7 +31,8 @@ Then run the container:
 $ docker run -p 8080:8080 <IMAGE ID>
 ```
 
-The endpoints will be available at `http://localhost:8080/`.
+The landing page will be available at `http://localhost:8080/hapi`
+with the default configuration.
 
 ## Running with an executable JAR
 
@@ -27,4 +44,11 @@ Then run the JAR:
 $ java -jar <JAR>
 ```
 
-The endpoints will be available at `http://localhost:8080/`.
+Or with a specific configuration file:
+
+```
+$ java -Dconfig.file=<CONF> -jar <JAR>
+```
+
+The landing page will be available at `http://localhost:8080/hapi`
+with the default configuration.

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,8 @@
 ThisBuild / organization := "lasp"
 ThisBuild / scalaVersion := "2.12.6"
 
-val http4sVersion = "0.18.17"
+val http4sVersion     = "0.18.17"
+val pureconfigVersion = "0.9.2"
 
 lazy val `hapi-server` = (project in file("."))
   .enablePlugins(DockerPlugin)
@@ -10,12 +11,14 @@ lazy val `hapi-server` = (project in file("."))
   .settings(dockerSettings)
   .settings(
     libraryDependencies ++= Seq(
-      "org.http4s"    %% "http4s-blaze-server" % http4sVersion,
-      "org.http4s"    %% "http4s-circe"        % http4sVersion,
-      "org.http4s"    %% "http4s-dsl"          % http4sVersion,
-      "org.http4s"    %% "http4s-scalatags"    % http4sVersion,
-      "ch.qos.logback" % "logback-classic"     % "1.2.3" % Runtime,
-      "org.scalatest" %% "scalatest"           % "3.0.5" % Test
+      "org.http4s"            %% "http4s-blaze-server"    % http4sVersion,
+      "org.http4s"            %% "http4s-circe"           % http4sVersion,
+      "org.http4s"            %% "http4s-dsl"             % http4sVersion,
+      "org.http4s"            %% "http4s-scalatags"       % http4sVersion,
+      "ch.qos.logback"         % "logback-classic"        % "1.2.3" % Runtime,
+      "com.github.pureconfig" %% "pureconfig"             % pureconfigVersion,
+      "com.github.pureconfig" %% "pureconfig-cats-effect" % pureconfigVersion,
+      "org.scalatest"         %% "scalatest"              % "3.0.5" % Test
     ),
     Test / logBuffered := false
   )

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -1,0 +1,8 @@
+port = 8080
+port = ${?HAPI_PORT}
+
+mapping = "/"
+mapping = ${?HAPI_MAPPING}
+
+catalog-dir = "catalog"
+catalog-dir = ${?HAPI_CATALOG}

--- a/src/main/scala/lasp/hapi/service/latis2/Latis2Interpreter.scala
+++ b/src/main/scala/lasp/hapi/service/latis2/Latis2Interpreter.scala
@@ -11,18 +11,12 @@ import latis.ops.Operation
 import latis.ops.Projection
 import latis.reader.CatalogReader
 
-/**
- * Interpreter for HAPI algebras using LaTiS 2.
- *
- * @constructor Create an interpreter that reads the catalog from the
- *              given directory.
- * @param dir directory that is the root of the catalog
- */
-class Latis2Interpreter[F[_]: Sync](dir: String) extends HapiInterpreter[F] {
+/** Interpreter for HAPI algebras using LaTiS 2. */
+class Latis2Interpreter[F[_]: Sync] extends HapiInterpreter[F] {
 
   override val getCatalog: F[List[Dataset]] =
     Sync[F].delay {
-      new CatalogReader(dir).getDataset() match {
+      new CatalogReader().getDataset() match {
         case dm.Dataset(Function(it)) =>
           it.map {
             case Sample(Text(name), _) =>

--- a/src/main/scala/lasp/hapi/util/HapiConfig.scala
+++ b/src/main/scala/lasp/hapi/util/HapiConfig.scala
@@ -1,0 +1,14 @@
+package lasp.hapi.util
+
+/**
+ * Configuration for HAPI
+ *
+ * @param mapping URL component before /hapi
+ * @param port port to listen on
+ * @param catalogDir directory containing catalog
+ */
+final case class HapiConfig(
+  mapping: String,
+  port: Int,
+  catalogDir: String
+)


### PR DESCRIPTION
After looking at a few options I've settled on giving [PureConfig][pc] a shot. It wraps the [Lightbend Config][lc] library with some nice things and has [support for cats][pc-cats] and [cats-effect][pc-cats-effect].

What I like most about PureConfig is that it will read the configuration into a case class. This way your configuration is a value that you could generate by hand rather than something magic that can only come from a configuration file or system properties. `HapiConfig` is the case class I've introduced to hold the configuration.

Closes #14.

[hocon]: https://github.com/lightbend/config/blob/master/HOCON.md
[lc]: https://github.com/lightbend/config
[pc]: https://github.com/pureconfig/pureconfig
[pc-cats]: https://github.com/pureconfig/pureconfig/tree/master/modules/cats
[pc-cats-effect]: https://github.com/pureconfig/pureconfig/tree/master/modules/cats-effect