### PR TITLE
Clean up JSON responses

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -11,6 +11,7 @@ lazy val `hapi-server` = (project in file("."))
   .settings(dockerSettings)
   .settings(
     libraryDependencies ++= Seq(
+      "io.circe"              %% "circe-generic"          % "0.9.3",
       "org.http4s"            %% "http4s-blaze-server"    % http4sVersion,
       "org.http4s"            %% "http4s-circe"           % http4sVersion,
       "org.http4s"            %% "http4s-dsl"             % http4sVersion,

--- a/src/main/scala/lasp/hapi/service/InfoResponse.scala
+++ b/src/main/scala/lasp/hapi/service/InfoResponse.scala
@@ -1,6 +1,8 @@
 package lasp.hapi.service
 
 import io.circe.Encoder
+import io.circe.Json
+import io.circe.syntax._
 
 /**
  * Represents a response from the `info` service.
@@ -23,18 +25,10 @@ object InfoResponse {
    * Note that we are flattening out the `metadata` field.
    */
   implicit val encoder: Encoder[InfoResponse] =
-    Encoder.forProduct15(
-      "HAPI", "status", "parameters", "startDate", "stopDate",
-      "timeStampLocation", "cadence", "sampleStartDate", "sampleStopDate",
-      "description", "resourceURL", "creationDate", "modificationDate",
-      "contact", "contactID"
-    ) { x =>
-      (x.version, x.status, x.metadata.parameters,
-        x.metadata.startDate, x.metadata.stopDate,
-        x.metadata.timeStampLocation, x.metadata.cadence,
-        x.metadata.sampleStartDate, x.metadata.sampleStopDate,
-        x.metadata.description, x.metadata.resourceURL,
-        x.metadata.creationDate, x.metadata.modificationDate,
-        x.metadata.contact, x.metadata.contactID)
+    new Encoder[InfoResponse] {
+      override def apply(x: InfoResponse): Json =
+        Encoder[Metadata].apply(x.metadata).deepMerge(
+          Json.obj("HAPI" -> x.version.asJson, "status" -> x.status.asJson)
+        )
     }
 }

--- a/src/main/scala/lasp/hapi/service/Metadata.scala
+++ b/src/main/scala/lasp/hapi/service/Metadata.scala
@@ -1,6 +1,8 @@
 package lasp.hapi.service
 
 import cats.data.NonEmptyList
+import io.circe.Encoder
+import io.circe.generic.semiauto._
 
 /**
  * Represents metadata for HAPI datasets.
@@ -34,3 +36,18 @@ final case class Metadata(
   contact: Option[String],
   contactID: Option[String]
 )
+
+object Metadata {
+
+  /**
+   * JSON encoder
+   *
+   * This encoder will drop parameters that are None.
+   */
+  implicit val encoder: Encoder[Metadata] =
+    deriveEncoder[Metadata].mapJsonObject {
+      _.filter {
+        case (_, v) => !v.isNull
+      }
+    }
+}


### PR DESCRIPTION
This commit cleans up our JSON responses by removing unset optional parameters from the response.

Many parts of the info response are optional, and the default encoders translate `None` into `null`, so we had large JSON objects full of `null`s. The new encoders introduced by this commit remove keys with null values, with the exception of "`fill` which is required to be present even when null.

I've also had to explicitly rename `dType` to `type` because the derived encoder will use the name of the parameter from the case class.

Closes #45.