### PR TITLE
Make LaTiS 2 the default interpreter

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ There are two methods for configuring the HAPI server:
 | ----------------- | -------------------- | ---------------------------- | ---------------- |
 | `port`            | `HAPI_PORT`          | Port to listen on            | 8080             |
 | `mapping`         | `HAPI_MAPPING`       | URL segment before `/hapi`   | "/"              |
+| `catalog-dir`     | `HAPI_CATALOG`       | Catalog directory            | `./catalog` (JAR); `/srv/hapi` (Docker) |
 
 [hocon]: https://github.com/lightbend/config/blob/master/HOCON.md
 
@@ -28,7 +29,7 @@ must be running.
 Then run the container:
 
 ```
-$ docker run -p 8080:8080 <IMAGE ID>
+$ docker run -p 8080:8080 --mount type=bind,src=<CATALOG DIR>,dst=/srv/hapi <IMAGE ID>
 ```
 
 The landing page will be available at `http://localhost:8080/hapi`

--- a/build.sbt
+++ b/build.sbt
@@ -57,7 +57,10 @@ lazy val dockerSettings = Seq(
   },
   docker / dockerfile := {
     val jarFile = (Compile / packageBin / sbt.Keys.`package`).value
-    val classpath = (Runtime / managedClasspath).value
+    val classpath = Seq(
+      (Runtime / managedClasspath).value,
+      (Runtime / internalDependencyAsJars).value
+    ).flatten
     val mainclass = (Compile / packageBin / mainClass).value.getOrElse {
       sys.error("Expected exactly one main class")
     }
@@ -71,6 +74,7 @@ lazy val dockerSettings = Seq(
       copy(classpath.files, "/app/")
       copy(jarFile, jarTarget)
       expose(8080)
+      env("HAPI_CATALOG", "/srv/hapi")
       entryPoint("java", "-cp", cp, mainclass)
     }
   }

--- a/src/main/scala/lasp/hapi/server/HapiServer.scala
+++ b/src/main/scala/lasp/hapi/server/HapiServer.scala
@@ -11,7 +11,6 @@ import org.http4s.HttpService
 import org.http4s.server.blaze._
 import pureconfig.module.catseffect._
 
-import lasp.hapi.service.HapiInterpreter
 import lasp.hapi.service.HapiService
 import lasp.hapi.service.LandingPageService
 import lasp.hapi.util.HapiConfig
@@ -27,7 +26,9 @@ object HapiServer extends HapiServerApp[IO]
 abstract class HapiServerApp[F[_]: Effect] extends StreamApp[F] {
 
   private val hapiService: HttpService[F] =
-    new HapiService(HapiInterpreter.noopInterpreter[F]).service
+    new HapiService(
+      new lasp.hapi.service.latis2.Latis2Interpreter[F]
+    ).service
 
   private val landingPage: HttpService[F] =
     new LandingPageService().service


### PR DESCRIPTION
Most of the changes required to make LaTiS 2 the default were finding the appropriate classpath to copy into the Docker image.

The confusing part was the fact that we're depending on LaTiS 2 as a source dependency. Apparently we can get the JAR through `internalDependencyAsJars`, so I just add that to the things being copied into the image.

Closes #43.