### PR TITLE
Support datasets with a second dimension

### DIFF
--- a/src/main/scala/lasp/hapi/service/Bin.scala
+++ b/src/main/scala/lasp/hapi/service/Bin.scala
@@ -1,13 +1,16 @@
 package lasp.hapi.service
 
 import io.circe.Encoder
+import io.circe.generic.semiauto._
 
 /**
  * Represents a parameter's bin.
  *
+ * At least one of `centers` or `ranges` must be given.
+ *
  * @param name name of dimension
- * @param centers center of bins (only if `ranges` is not defined)
- * @param ranges boundaries of each bin (only if `centers` is not defined)
+ * @param centers center of bins
+ * @param ranges boundaries of each bin
  * @param units units for bin ranges or center values
  * @param description description of bin
  */
@@ -23,9 +26,15 @@ object Bin {
 
   /** JSON encoder */
   implicit val encoder: Encoder[Bin] =
-    Encoder.forProduct5(
-      "name", "centers", "ranges", "units", "description"
-    ) { x =>
-      (x.name, x.centers, x.ranges, x.units, x.description)
+    deriveEncoder[Bin].mapJsonObject { obj =>
+      obj.filter {
+        case ("centers", _) =>
+          // Keep "centers" regardless of its value if "ranges" is
+          // null or missing.
+          obj("ranges").map(_.isNull).getOrElse(true)
+        case (_, v)         =>
+          // Remove all other null fields.
+          !v.isNull
+      }
     }
 }

--- a/src/test/scala/lasp/hapi/service/BinSpec.scala
+++ b/src/test/scala/lasp/hapi/service/BinSpec.scala
@@ -1,0 +1,46 @@
+package lasp.hapi.service
+
+import io.circe._
+import io.circe.syntax._
+import org.scalatest.FlatSpec
+
+class BinSpec extends FlatSpec {
+
+  "The Bin encoder" should "keep 'centers' if 'ranges' is not defined" in {
+    val bin = Bin("", None, None, "", Option(""))
+
+    val expected = Json.obj(
+      ("name", "".asJson),
+      ("centers", Json.Null),
+      ("units", "".asJson),
+      ("description", "".asJson)
+    )
+
+    assert(bin.asJson == expected)
+  }
+
+  it should "remove 'centers' if null and 'ranges' is defined" in {
+    val bin = Bin("", None, Option(List((1,2))), "", Option(""))
+
+    val expected = Json.obj(
+      ("name", "".asJson),
+      ("ranges", Json.arr(Json.arr(1.asJson, 2.asJson))),
+      ("units", "".asJson),
+      ("description", "".asJson)
+    )
+
+    assert(bin.asJson == expected)
+  }
+
+  it should "remove null values otherwise" in {
+    val bin = Bin("", None, None, "", None)
+
+    val expected = Json.obj(
+      ("name", "".asJson),
+      ("centers", Json.Null),
+      ("units", "".asJson),
+    )
+
+    assert(bin.asJson == expected)
+  }
+}


### PR DESCRIPTION
This PR adds support for 2D datasets to the LaTiS 2 interpreter. Because we're now using `Bin` objects I've also cleaned up the JSON we generate from them.

Check out the LaTiS code to make sure I'm not doing anything crazy.

Closes #52.