### PR TITLE
Support optional metadata

### DIFF
--- a/src/main/scala/lasp/hapi/service/TimeStampLocation.scala
+++ b/src/main/scala/lasp/hapi/service/TimeStampLocation.scala
@@ -20,6 +20,15 @@ final case object Other extends TimeStampLocation
 
 object TimeStampLocation {
 
+  def apply(str: String): Option[TimeStampLocation] =
+    str.toLowerCase match {
+      case "begin"  => Option(Begin)
+      case "center" => Option(Center)
+      case "end"    => Option(End)
+      case "other"  => Option(Other)
+      case _        => None
+    }
+
   /** JSON encoder */
   implicit val encoder: Encoder[TimeStampLocation] =
     Encoder.instance {

--- a/src/main/scala/lasp/hapi/service/latis2/Latis2Util.scala
+++ b/src/main/scala/lasp/hapi/service/latis2/Latis2Util.scala
@@ -68,6 +68,7 @@ object Latis2Util {
                 val size = g.getMetadata("length").get.toInt
                 val name = g.getDomain.getName
                 val units = g.getDomain.getMetadata("units").get
+                val desc = g.getDomain.getMetadata("description")
                 // Need to read the first sample in order to get the
                 // domain of the inner function.
                 val bin = it.next match {
@@ -75,7 +76,7 @@ object Latis2Util {
                     val ws = it.map {
                       case Sample(Number(w), _) => w
                     }.toList
-                    Bin(name, ws.some, None, units, None)
+                    Bin(name, ws.some, None, units, desc)
                 }
                 // Get metadata for the parameters and add the size
                 // and bin information.
@@ -94,16 +95,16 @@ object Latis2Util {
             NonEmptyList(tParam, params),
             tMin,
             tMax,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None
+            timeMd.get("timeStampLocation").flatMap(TimeStampLocation(_)),
+            timeMd.get("cadence"),
+            ds.getMetadata.get("sampleStartDate"),
+            ds.getMetadata.get("sampleStopDate"),
+            ds.getMetadata.get("description"),
+            ds.getMetadata.get("resourceURL"),
+            ds.getMetadata.get("creationDate"),
+            ds.getMetadata.get("modificationDate"),
+            ds.getMetadata.get("contact"),
+            ds.getMetadata.get("contactID")
           )
       }
    }.flatten
@@ -121,8 +122,8 @@ object Latis2Util {
             Option(24),
             "UTC",
             None,
-            None,
-            None,
+            md.get("missing_value"),
+            md.get("description"),
             None
           )
         case _: Real =>
@@ -132,8 +133,8 @@ object Latis2Util {
             None,
             md.get("units").get,
             None,
-            None,
-            None,
+            md.get("missing_value"),
+            md.get("description"),
             None
           )
         case _: Integer =>
@@ -143,8 +144,8 @@ object Latis2Util {
             None,
             md.get("units").get,
             None,
-            None,
-            None,
+            md.get("missing_value"),
+            md.get("description"),
             None
           )
         case _: Text =>
@@ -154,8 +155,8 @@ object Latis2Util {
             md.get("length").map(_.toInt),
             md.get("units").get,
             None,
-            None,
-            None,
+            md.get("missing_value"),
+            md.get("description"),
             None
           )
       }


### PR DESCRIPTION
The commit adds support for the optional metadata items.

See the [spec][info] for descriptions of each item.

I've kept most of the names as-is because they'll be easy to change later. If you (@dlindhol) know of a better name, let me know and I'll change it.

One question I have is in regards to the cadence and time stamp location: should those be on the dataset as a whole, or on the time variable? (Right now I have them on the dataset because it was where everything else was.)

Closes #53.

[info]: https://github.com/hapi-server/data-specification/blob/master/hapi-2.0.0/HAPI-data-access-spec-2.0.0.md#info