### PR TITLE
Improve logging

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -17,6 +17,7 @@ lazy val `hapi-server` = (project in file("."))
       "org.http4s"            %% "http4s-circe"           % http4sVersion,
       "org.http4s"            %% "http4s-dsl"             % http4sVersion,
       "org.http4s"            %% "http4s-scalatags"       % http4sVersion,
+      "org.log4s"             %% "log4s"                  % "1.6.1",
       "ch.qos.logback"         % "logback-classic"        % "1.2.3" % Runtime,
       "com.github.pureconfig" %% "pureconfig"             % pureconfigVersion,
       "com.github.pureconfig" %% "pureconfig-cats-effect" % pureconfigVersion,

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,0 +1,13 @@
+<configuration>
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <logger name="org.http4s" level="INFO" />
+
+  <root level="DEBUG">
+    <appender-ref ref="STDOUT" />
+  </root>
+</configuration>

--- a/src/main/scala/lasp/hapi/service/HapiService.scala
+++ b/src/main/scala/lasp/hapi/service/HapiService.scala
@@ -7,6 +7,7 @@ import cats.implicits._
 import org.http4s.HttpService
 import org.http4s.server.middleware.CORS
 import org.http4s.server.middleware.CORSConfig
+import org.http4s.server.middleware.Logger
 
 /**
  * A grouping of all four required HAPI endpoints.
@@ -45,7 +46,9 @@ class HapiService[F[_]: Effect](interpreter: HapiInterpreter[F]) {
       new CatalogService[F](interpreter).service <+>
       new DataService[F](interpreter).service
     }
-    CORS(service, corsConfig)
+    Logger(true, false)(
+      CORS(service, corsConfig)
+    )
   }
 }
 

--- a/src/main/scala/lasp/hapi/service/InfoService.scala
+++ b/src/main/scala/lasp/hapi/service/InfoService.scala
@@ -6,10 +6,13 @@ import io.circe.syntax._
 import org.http4s.HttpService
 import org.http4s.circe._
 import org.http4s.dsl.Http4sDsl
+import org.log4s._
 
 /** Implements the `/info` endpoint. */
 class InfoService[F[_]: Effect](alg: InfoAlgebra[F]) extends Http4sDsl[F] {
   import QueryDecoders._
+
+  private[this] val logger = getLogger
 
   val service: HttpService[F] =
     HttpService[F] {
@@ -21,13 +24,17 @@ class InfoService[F[_]: Effect](alg: InfoAlgebra[F]) extends Http4sDsl[F] {
           case UnknownId(_)    => Status.`1406`
           case UnknownParam(_) => Status.`1407`
         }.fold(
-          err => NotFound(HapiError(err).asJson),
+          err => {
+            logger.info(err.message)
+            NotFound(HapiError(err).asJson)
+          },
           res => Ok(
             InfoResponse(HapiService.version, Status.`1200`, res).asJson
           )
         ).flatten
       // Return a 1400 error if the required parameters are not given.
       case GET -> Root / "hapi" / "info" :? _ =>
+        logger.info(Status.`1400`.message)
         BadRequest(HapiError(Status.`1400`).asJson)
     }
 }


### PR DESCRIPTION
I've wrapped the HAPI service in the `http4s` logging middleware, which logs requests and responses. Because some of our responses are data, I've disabled logging the bodies of responses. Instead, when we generate a HAPI error, I log the associated error message.

Blaze will already log exceptions that occur during the process of responding to a request.

There is certainly more work to be done here. I'm rethinking how we handle errors, and that will impact how we log them. This is probably good enough for now.

Closes #60.