### PR TITLE
Revive hapi-server

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,17 +1,41 @@
 ThisBuild / organization := "io.latis-data"
-ThisBuild / scalaVersion := "2.12.8"
+ThisBuild / scalaVersion := "2.13.3"
+
+val nexus = "https://artifacts.pdmz.lasp.colorado.edu/repository/"
 
 val http4sVersion = "0.20.13"
+val latisVersion = "190a220b0abe02ace93940d81c8606bd35ccae62" //newest: "322efe5eb661d72b1ed688ca3c9f91fadb9fd4ef"
+val latis3HapiVersion = "59f1d2391f3670c20773d0908c0c6ba3f73f0f8d"
+
+lazy val `latis3-core` = ProjectRef(
+  uri(s"git://github.com/latis-data/latis3.git#$latisVersion"),
+  "core"
+)
+
+lazy val `latis3-service-interface` = ProjectRef(
+  uri(s"git://github.com/latis-data/latis3.git#$latisVersion"),
+  "service-interface"
+)
+
+lazy val `latis3-server` = ProjectRef(
+  uri(s"git://github.com/latis-data/latis3.git#$latisVersion"),
+  "server"
+)
+
+lazy val `latis3-hapi` = ProjectRef(
+  uri(s"git://github.com/latis-data/latis3-hapi.git#$latis3HapiVersion"),
+  "server"
+)
 
 lazy val root = (project in file("."))
+  .dependsOn(`latis3-core`)
+  .dependsOn(`latis3-service-interface`)
+  .dependsOn(`latis3-server`)
+  .dependsOn(`latis3-hapi`)
   .settings(compilerFlags)
   .settings(
     name := "hapi-server",
     libraryDependencies ++= Seq(
-      "io.latis-data" %% "latis3-core" % "0.1.0-SNAPSHOT",
-      "io.latis-data" %% "latis3-service-interface" % "0.1.0-SNAPSHOT",
-      "io.latis-data" %% "latis3-server" % "0.1.0-SNAPSHOT",
-      "io.latis-data" %% "latis3-hapi" % "0.1.0-SNAPSHOT",
       "io.latis-data" %% "dap2-service-interface" % "0.1.0-SNAPSHOT",
       "org.http4s" %% "http4s-dsl" % http4sVersion % Provided,
       "org.http4s" %% "http4s-circe" % http4sVersion,
@@ -20,6 +44,10 @@ lazy val root = (project in file("."))
       // coursier only seems to include compile dependencies when
       // building a standalone executable (see coursier/coursier#552)
       "ch.qos.logback" % "logback-classic" % "1.2.3"
+    ),
+    resolvers ++= Seq(
+      "Nexus Release" at nexus + "web-releases",
+      "Nexus Snapshot" at nexus + "web-snapshots"
     )
   )
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,53 +1,37 @@
 ThisBuild / organization := "io.latis-data"
-ThisBuild / scalaVersion := "2.13.3"
+ThisBuild / scalaVersion := "2.13.5"
 
 val nexus = "https://artifacts.pdmz.lasp.colorado.edu/repository/"
 
-val http4sVersion = "0.20.13"
-val latisVersion = "190a220b0abe02ace93940d81c8606bd35ccae62" //newest: "322efe5eb661d72b1ed688ca3c9f91fadb9fd4ef"
-val latis3HapiVersion = "59f1d2391f3670c20773d0908c0c6ba3f73f0f8d"
+val http4sVersion = "0.21.22"
+val latisVersion = "322efe5e"
 
-lazy val `latis3-core` = ProjectRef(
-  uri(s"git://github.com/latis-data/latis3.git#$latisVersion"),
-  "core"
-)
-
-lazy val `latis3-service-interface` = ProjectRef(
-  uri(s"git://github.com/latis-data/latis3.git#$latisVersion"),
-  "service-interface"
-)
-
-lazy val `latis3-server` = ProjectRef(
-  uri(s"git://github.com/latis-data/latis3.git#$latisVersion"),
-  "server"
-)
-
-lazy val `latis3-hapi` = ProjectRef(
-  uri(s"git://github.com/latis-data/latis3-hapi.git#$latis3HapiVersion"),
-  "server"
-)
+//lazy val `latis3-hapi` = ProjectRef(file("../latis3-hapi"), "hapi")
 
 lazy val root = (project in file("."))
-  .dependsOn(`latis3-core`)
-  .dependsOn(`latis3-service-interface`)
-  .dependsOn(`latis3-server`)
-  .dependsOn(`latis3-hapi`)
   .settings(compilerFlags)
+  //.dependsOn(`latis3-hapi`)
   .settings(
     name := "hapi-server",
     libraryDependencies ++= Seq(
-      "io.latis-data" %% "dap2-service-interface" % "0.1.0-SNAPSHOT",
-      "org.http4s" %% "http4s-dsl" % http4sVersion % Provided,
-      "org.http4s" %% "http4s-circe" % http4sVersion,
-      "org.http4s" %% "http4s-scalatags" % http4sVersion,
-      "io.circe" %% "circe-generic" % "0.12.3",
+      "com.github.latis-data.latis3" %% "latis3-core"              % latisVersion,
+      "com.github.latis-data.latis3" %% "latis3-service-interface" % latisVersion,
+      "com.github.latis-data.latis3" %% "latis3-server"            % latisVersion,
+      "com.github.latis-data.latis3" %% "dap2-service-interface"   % latisVersion,
+      //"com.github.latis-data"        %% "latis3-hapi"              % "59f1d239",
+      "org.http4s"                   %% "http4s-dsl"               % http4sVersion % Provided,
+      "org.http4s"                   %% "http4s-circe"             % http4sVersion,
+      "org.http4s"                   %% "http4s-scalatags"         % http4sVersion,
+      "io.circe"                     %% "circe-generic"            % "0.13.0",
       // coursier only seems to include compile dependencies when
       // building a standalone executable (see coursier/coursier#552)
-      "ch.qos.logback" % "logback-classic" % "1.2.3"
+      "ch.qos.logback"                % "logback-classic"          % "1.2.3"
     ),
     resolvers ++= Seq(
       "Nexus Release" at nexus + "web-releases",
-      "Nexus Snapshot" at nexus + "web-snapshots"
+      "Nexus Snapshot" at nexus + "web-snapshots",
+      "Unidata" at "https://artifacts.unidata.ucar.edu/content/repositories/unidata-releases",
+      "jitpack" at "https://jitpack.io"
     )
   )
 
@@ -60,7 +44,6 @@ lazy val compilerFlags = Seq(
     "-unchecked",
     "-Xfuture",
     "-Xlint:-unused,_",
-    "-Ypartial-unification",
     "-Ywarn-dead-code",
     "-Ywarn-numeric-widen",
     "-Ywarn-unused",

--- a/build.sbt
+++ b/build.sbt
@@ -1,8 +1,6 @@
 ThisBuild / organization := "io.latis-data"
 ThisBuild / scalaVersion := "2.13.5"
 
-val nexus = "https://artifacts.pdmz.lasp.colorado.edu/repository/"
-
 val http4sVersion = "0.21.22"
 val latisVersion = "91b09198"
 
@@ -40,7 +38,6 @@ lazy val compilerFlags = Seq(
     "-feature",
     "-language:higherKinds",
     "-unchecked",
-    "-Xfuture",
     "-Xlint:-unused,_",
     "-Ywarn-dead-code",
     "-Ywarn-numeric-widen",

--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ ThisBuild / scalaVersion := "2.13.5"
 val nexus = "https://artifacts.pdmz.lasp.colorado.edu/repository/"
 
 val http4sVersion = "0.21.22"
-val latisVersion = "322efe5e"
+val latisVersion = "91b09198"
 
 lazy val `latis3-hapi` = ProjectRef(file("../latis3-hapi"), "hapi")
 

--- a/build.sbt
+++ b/build.sbt
@@ -6,11 +6,11 @@ val nexus = "https://artifacts.pdmz.lasp.colorado.edu/repository/"
 val http4sVersion = "0.21.22"
 val latisVersion = "322efe5e"
 
-//lazy val `latis3-hapi` = ProjectRef(file("../latis3-hapi"), "hapi")
+lazy val `latis3-hapi` = ProjectRef(file("../latis3-hapi"), "hapi")
 
 lazy val root = (project in file("."))
   .settings(compilerFlags)
-  //.dependsOn(`latis3-hapi`)
+  .dependsOn(`latis3-hapi`)
   .settings(
     name := "hapi-server",
     libraryDependencies ++= Seq(
@@ -18,7 +18,7 @@ lazy val root = (project in file("."))
       "com.github.latis-data.latis3" %% "latis3-service-interface" % latisVersion,
       "com.github.latis-data.latis3" %% "latis3-server"            % latisVersion,
       "com.github.latis-data.latis3" %% "dap2-service-interface"   % latisVersion,
-      //"com.github.latis-data"        %% "latis3-hapi"              % "59f1d239",
+      //"com.github.latis-data"         % "latis3-hapi"              % "updates-SNAPSHOT", //TODO: update once PR gets merged
       "org.http4s"                   %% "http4s-dsl"               % http4sVersion % Provided,
       "org.http4s"                   %% "http4s-circe"             % http4sVersion,
       "org.http4s"                   %% "http4s-scalatags"         % http4sVersion,

--- a/build.sbt
+++ b/build.sbt
@@ -4,11 +4,8 @@ ThisBuild / scalaVersion := "2.13.5"
 val http4sVersion = "0.21.22"
 val latisVersion = "91b09198"
 
-lazy val `latis3-hapi` = ProjectRef(file("../latis3-hapi"), "hapi") //TODO: pull from jitpack once PR gets merged
-
 lazy val root = (project in file("."))
   .settings(compilerFlags)
-  .dependsOn(`latis3-hapi`)
   .settings(
     name := "hapi-server",
     libraryDependencies ++= Seq(
@@ -16,7 +13,7 @@ lazy val root = (project in file("."))
       "com.github.latis-data.latis3" %% "latis3-service-interface" % latisVersion,
       "com.github.latis-data.latis3" %% "latis3-server"            % latisVersion,
       "com.github.latis-data.latis3" %% "dap2-service-interface"   % latisVersion,
-      //"com.github.latis-data"         % "latis3-hapi"              % "updates-SNAPSHOT", //TODO: update once PR gets merged
+      "com.github.latis-data"         % "latis3-hapi"              % "4427515e",
       "org.http4s"                   %% "http4s-dsl"               % http4sVersion % Provided,
       "org.http4s"                   %% "http4s-circe"             % http4sVersion,
       "org.http4s"                   %% "http4s-scalatags"         % http4sVersion,

--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ val nexus = "https://artifacts.pdmz.lasp.colorado.edu/repository/"
 val http4sVersion = "0.21.22"
 val latisVersion = "91b09198"
 
-lazy val `latis3-hapi` = ProjectRef(file("../latis3-hapi"), "hapi")
+lazy val `latis3-hapi` = ProjectRef(file("../latis3-hapi"), "hapi") //TODO: pull from jitpack once PR gets merged
 
 lazy val root = (project in file("."))
   .settings(compilerFlags)
@@ -28,8 +28,6 @@ lazy val root = (project in file("."))
       "ch.qos.logback"                % "logback-classic"          % "1.2.3"
     ),
     resolvers ++= Seq(
-      "Nexus Release" at nexus + "web-releases",
-      "Nexus Snapshot" at nexus + "web-snapshots",
       "Unidata" at "https://artifacts.unidata.ucar.edu/content/repositories/unidata-releases",
       "jitpack" at "https://jitpack.io"
     )

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.13
+sbt.version=1.5.0

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.8
+sbt.version=1.3.13

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.5.0
+sbt.version=1.5.1

--- a/src/main/scala/latis/ops/ToHapiTime.scala
+++ b/src/main/scala/latis/ops/ToHapiTime.scala
@@ -40,12 +40,10 @@ class ToHapiTime extends MapOperation {
         Time(md)
       }
 
-      Either.catchOnly[LatisException] {
-        tHapi.fold(
-          _ => throw LatisException("Failed to apply to model"),
-          Function(_, r)
-        )
-      }
+      tHapi.fold(
+        _ => Left(LatisException("Failed to apply to model")),
+        time => Right(Function(time, r))
+      )
     case _ => Left(LatisException("Failed to apply to model"))
   }
 

--- a/src/main/scala/latis/ops/ToHapiTime.scala
+++ b/src/main/scala/latis/ops/ToHapiTime.scala
@@ -4,7 +4,6 @@ import cats.implicits._
 
 import latis.data.Number
 import latis.data.Sample
-import latis.data.SampledFunction
 import latis.data.Text
 import latis.metadata.Metadata
 import latis.model._
@@ -15,6 +14,7 @@ import latis.time.TimeFormat
 import latis.time.TimeScale
 import latis.units.UnitConverter
 import latis.util.HapiUtils
+import latis.util.LatisException
 
 /**
  * An operation that converts a time variable to HAPI time strings.
@@ -23,10 +23,10 @@ import latis.util.HapiUtils
  * served via the HAPI interface, it assumes that the outermost domain
  * variable is time.
  */
-class ToHapiTime extends UnaryOperation {
+class ToHapiTime extends MapOperation {
 
   // Convert the units and coverage in the time metadata.
-  override def applyToModel(model: DataType): DataType = model match {
+  override def applyToModel(model: DataType): Either[LatisException, DataType] = model match {
     case Function(t: Time, r) =>
       val tHapi: Either[InfoError, Time] = for {
         fmt  <- getMetadata(t, "units")
@@ -40,43 +40,43 @@ class ToHapiTime extends UnaryOperation {
         Time(md)
       }
 
-      tHapi.fold(
-        _ => throw new RuntimeException("Failed to apply to model"),
-        Function(_, r)
-      )
-    case _ => throw new RuntimeException("Failed to apply to model")
+      Either.catchOnly[LatisException] {
+        tHapi.fold(
+          _ => throw LatisException("Failed to apply to model"),
+          Function(_, r)
+        )
+      }
+    case _ => Left(LatisException("Failed to apply to model"))
   }
 
   // Convert the first Data in the domain (assumed to be time, because
   // this is for HAPI).
-  override def applyToData(data: SampledFunction, model: DataType): SampledFunction = {
+  override def mapFunction(model: DataType): Sample => Sample = {
     val time: Time = model match {
       case Function(t: Time, _) => t
-      case _ => throw new RuntimeException("Failed to apply to data")
+      case _ => throw new RuntimeException("Failed to create map function: domain is not time")
     }
+    val converter = UnitConverter(time.timeScale, TimeScale.Default)
 
-    if (time.timeFormat.map(_ != TimeFormat.Iso).getOrElse(true)) {
-      val converter = UnitConverter(time.timeScale, TimeScale.Default)
-      data.map(mkMapFunction(converter, time))
-    } else data
-  }
+    if (!time.timeFormat.contains(TimeFormat.Iso)) {
+      case Sample(Number(t) :: rest, r) =>
+        val tC = converter.convert(t).toLong
+        val tF = TimeFormat.formatIso(tC)
 
-  private def mkMapFunction(converter: UnitConverter, dt: Time): Sample => Sample = {
-    case Sample(Number(t) :: rest, r) =>
-      val tC = converter.convert(t).toLong
-      val tF = TimeFormat.formatIso(tC)
+        Sample(tF :: rest, r)
+      case Sample(Text(t) :: rest, r)   =>
+        val fmt = time.timeFormat.getOrElse {
+          throw new LatisException("Failed to create map function: TimeFormat not found")
+        }
+        val tD = fmt.parse(t).fold(throw _, _.toDouble)
+        val tC = converter.convert(tD).toLong
+        val tF = TimeFormat.formatIso(tC)
 
-      Sample(tF :: rest, r)
-    case Sample(Text(t) :: rest, r)   =>
-      val fmt = dt.timeFormat.getOrElse {
-        throw new RuntimeException("Failed to apply to data")
-      }
-      val tD = fmt.parse(t).fold(throw _, _.toDouble)
-      val tC = converter.convert(tD).toLong
-      val tF = TimeFormat.formatIso(tC)
-
-      Sample(tF :: rest, r)
-    case _ => throw new RuntimeException("Failed to apply to data")
+        Sample(tF :: rest, r)
+      case _ => throw new LatisException("Failed to create map function: invalid Sample")
+    } else {
+      s: Sample => s
+    }
   }
 
   private def getMetadata(dt: DataType, key: String): Either[MetadataError, String] =

--- a/src/main/scala/latis/service/hapi/HapiService.scala
+++ b/src/main/scala/latis/service/hapi/HapiService.scala
@@ -7,6 +7,8 @@ import cats.effect.IO
 import cats.implicits._
 import org.http4s.HttpRoutes
 
+import latis.catalog.Catalog
+
 // TODO: Would this be better in latis.service?
 //
 // That way, the package could be:
@@ -25,7 +27,7 @@ import latis.server.ServiceInterface
  * those four endpoints and a landing page and exposes them as a
  * single service that implements the HAPI spec.
  */
-class HapiService extends ServiceInterface {
+class HapiService(catalog: Catalog) extends ServiceInterface(catalog) {
 
   // TODO: We want to get this from the server.
   private implicit val cs: ContextShift[IO] =
@@ -33,7 +35,7 @@ class HapiService extends ServiceInterface {
 
   /** A service composed of all four required HAPI endpoints. */
   override def routes: HttpRoutes[IO] = {
-    val interpreter = new Latis3Interpreter
+    val interpreter = new Latis3Interpreter(catalog)
 
     val service = {
       new LandingPageService[IO].service          <+>

--- a/src/main/scala/latis/service/hapi/InfoError.scala
+++ b/src/main/scala/latis/service/hapi/InfoError.scala
@@ -1,7 +1,7 @@
 package latis.service.hapi
 
 /** Base trait for errors returned by the info service. */
-sealed trait InfoError
+sealed trait InfoError extends Throwable
 
 /** Error for unknown dataset IDs. */
 final case class UnknownId(id: String) extends InfoError

--- a/src/main/scala/latis/service/hapi/Latis3Interpreter.scala
+++ b/src/main/scala/latis/service/hapi/Latis3Interpreter.scala
@@ -181,7 +181,7 @@ class Latis3Interpreter(catalog: Catalog) extends HapiInterpreter[IO] {
   private def makeProjection(params: Option[NonEmptyList[String]]): List[UnaryOperation] =
     params.map { ps =>
       val names: List[String] = "time" :: ps.toList
-      List(Projection(names.mkString(",")))
+      List(Projection.fromArgs(names).fold(throw _, identity))
     }.getOrElse(List.empty)
 
   private def hasVariable(ds: T, vname: String): Boolean = Identifier.fromString(vname)

--- a/src/main/scala/latis/util/HapiUtils.scala
+++ b/src/main/scala/latis/util/HapiUtils.scala
@@ -11,11 +11,12 @@ object HapiUtils {
 
   /** Convert a time value to a HAPI time given its original units. */
   def toHapiTime(fmt: String, value: String): Either[InfoError, String] = for {
-    fromTime <- Either.catchNonFatal(TimeFormat(fmt))
-    .flatMap(_.parse(value).map(_.toDouble))
-    .orElse(Either.catchNonFatal(value.toDouble))
-    .leftMap(_ => MetadataError("Unsupported time units"))
-    scale     = TimeScale(fmt)
+    fromTime <- TimeFormat.fromExpression(fmt)
+      .flatMap(_.parse(value).map(_.toDouble))
+      .orElse(Either.catchNonFatal(value.toDouble))
+      .leftMap(_ => MetadataError("Unsupported time units"))
+    scale    <- TimeScale.fromExpression(fmt)
+      .leftMap(_ => MetadataError("Unsupported time units"))
     converter = UnitConverter(scale, TimeScale.Default)
     toTime    = converter.convert(fromTime).toLong
   } yield TimeFormat.formatIso(toTime)


### PR DESCRIPTION
This PR brings a number of fixes and dependency updates to make `hapi-server` compatible with the latest `latis3` again.

Note that I'm waiting on the [related latis3-hapi PR](https://github.com/latis-data/latis3-hapi/pull/15) to get merged before I can point this `build.sbt` at it.
Like the other PR, I stopped short of making the whole repo idiomatic; I just made it work.