### PR TITLE
Format sum type

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ ThisBuild / organization := "io.latis-data"
 ThisBuild / scalaVersion := "2.13.6"
 
 val http4sVersion = "0.23.1"
-val latisVersion = "f9c06477"
+val latisVersion = "0e670a3"
 
 lazy val root = (project in file("."))
   .settings(
@@ -12,7 +12,7 @@ lazy val root = (project in file("."))
       "com.github.latis-data.latis3" %% "latis3-service-interface" % latisVersion,
       "com.github.latis-data.latis3" %% "latis3-server"            % latisVersion,
       "com.github.latis-data.latis3" %% "dap2-service-interface"   % latisVersion,
-      "com.github.latis-data"         % "latis3-hapi"              % "ccf8a6c3",
+      "com.github.latis-data"         % "latis3-hapi"              % "0abfb39",
       "org.http4s"                   %% "http4s-dsl"               % http4sVersion % Provided,
       "org.http4s"                   %% "http4s-circe"             % http4sVersion,
       "org.http4s"                   %% "http4s-scalatags"         % http4sVersion,

--- a/src/main/scala/latis/service/hapi/DataService.scala
+++ b/src/main/scala/latis/service/hapi/DataService.scala
@@ -54,7 +54,7 @@ class DataService[F[_]: Concurrent](
             inc       <- _inc.getOrElse(Include(false).validNel).bimap(
               _ => Status.`1410`, _.header
             ).toEither
-            fmt       <- _fmt.getOrElse(Format("csv").validNel).bimap(
+            fmt       <- _fmt.getOrElse(Csv.validNel).bimap(
               _ => Status.`1409`, _.format
             ).toEither
           } yield DataRequest(dataset, startTime, stopTime, params, inc, fmt)

--- a/src/main/scala/latis/service/hapi/Format.scala
+++ b/src/main/scala/latis/service/hapi/Format.scala
@@ -7,14 +7,25 @@ import org.http4s.QueryParameterValue
 import org.http4s.dsl.io._
 
 /** Wrapper for `format` parameter. */
-final case class Format(format: String) extends AnyVal
+sealed trait Format {
+  val format = ""
+}
 
 object Format {
+  final case object Csv extends Format {
+    override val format = "csv"
+  }
+  final case object Binary extends Format {
+    override val format = "binary"
+  }
+  final case object Json extends Format {
+    override val format = "json"
+  }
 
   implicit val formatDecoder: QueryParamDecoder[Format] =
     new QueryParamDecoder[Format] {
       override def decode(qpv: QueryParameterValue) = qpv.value match {
-        case fmt @ "csv" => Format(fmt).validNel
+        case "csv" => Csv.validNel
         case _ =>
           ParseFailure(
             "Invalid value for 'format' parameter",


### PR DESCRIPTION
As per issue @ https://github.com/lasp/hapi-server/issues/76 from Chris: 

"Rather than taking a string argument, change to a sum type with CSV, binary, and JSON constructors."