### PR TITLE
HAPI-73 set Time metadata size in ToHapiTime

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -20,7 +20,7 @@ lazy val root = (project in file("."))
       "io.circe"                     %% "circe-generic"            % "0.14.1",
       // coursier only seems to include compile dependencies when
       // building a standalone executable (see coursier/coursier#552)
-      "ch.qos.logback"                % "logback-classic"          % "1.2.5"
+      "ch.qos.logback"                % "logback-classic"          % "1.2.8"
     ),
     resolvers ++= Seq(
       "Unidata" at "https://artifacts.unidata.ucar.edu/content/repositories/unidata-releases",

--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,5 @@
 ThisBuild / organization := "io.latis-data"
-ThisBuild / scalaVersion := "2.13.6"
+ThisBuild / scalaVersion := "2.13.7"
 
 val http4sVersion = "0.23.1"
 val latisVersion = "2127cb7"

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 ThisBuild / organization := "io.latis-data"
 ThisBuild / scalaVersion := "2.13.7"
 
-val http4sVersion = "0.23.1"
+val http4sVersion = "0.23.7"
 val latisVersion = "2127cb7"
 
 lazy val root = (project in file("."))

--- a/build.sbt
+++ b/build.sbt
@@ -16,7 +16,7 @@ lazy val root = (project in file("."))
       "org.http4s"                   %% "http4s-dsl"               % http4sVersion % Provided,
       "org.http4s"                   %% "http4s-circe"             % http4sVersion,
       "org.http4s"                   %% "http4s-scalatags"         % http4sVersion,
-      "org.scalatest"                %% "scalatest"                % "3.0.9" % Test,
+      "org.scalatest"                %% "scalatest"                % "3.2.10" % Test,
       "io.circe"                     %% "circe-generic"            % "0.14.1",
       // coursier only seems to include compile dependencies when
       // building a standalone executable (see coursier/coursier#552)

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ ThisBuild / organization := "io.latis-data"
 ThisBuild / scalaVersion := "2.13.7"
 
 val http4sVersion = "0.23.7"
-val latisVersion = "2127cb7"
+val latisVersion = "823018c"
 
 lazy val root = (project in file("."))
   .settings(

--- a/src/main/scala/latis/ops/ToHapiTime.scala
+++ b/src/main/scala/latis/ops/ToHapiTime.scala
@@ -34,6 +34,7 @@ class ToHapiTime extends MapOperation {
         covP <- HapiUtils.parseCoverage(cov, fmt)
       } yield {
         val md = t.metadata ++ Metadata(
+          "size" -> "24",
           "units" -> TimeFormat.Iso.toString,
           "coverage" -> s"${covP._1}/${covP._2}"
         )

--- a/src/test/scala/latis/service/hapi/BinSpec.scala
+++ b/src/test/scala/latis/service/hapi/BinSpec.scala
@@ -2,9 +2,9 @@ package latis.service.hapi
 
 import io.circe._
 import io.circe.syntax._
-import org.scalatest.FlatSpec
+import org.scalatest.flatspec._
 
-class BinSpec extends FlatSpec {
+class BinSpec extends AnyFlatSpec {
 
   "The Bin encoder" should "keep 'centers' if 'ranges' is not defined" in {
     val bin = Bin("", None, None, "", Option(""))

--- a/src/test/scala/latis/service/hapi/CapabilitiesServiceSpec.scala
+++ b/src/test/scala/latis/service/hapi/CapabilitiesServiceSpec.scala
@@ -6,9 +6,9 @@ import io.circe._
 import io.circe.syntax._
 import org.http4s._
 import org.http4s.implicits._
-import org.scalatest.FlatSpec
+import org.scalatest.flatspec._
 
-class CapabilitiesServiceSpec extends FlatSpec {
+class CapabilitiesServiceSpec extends AnyFlatSpec {
 
   "The capabilities service" should "advertise CSV and Binary only" in {
     val req = Request[IO](Method.GET, uri"/capabilities")

--- a/src/test/scala/latis/service/hapi/CatalogServiceSpec.scala
+++ b/src/test/scala/latis/service/hapi/CatalogServiceSpec.scala
@@ -1,8 +1,8 @@
 package latis.service.hapi
 
-import org.scalatest.FlatSpec
+import org.scalatest.flatspec._
 
-class CatalogServiceSpec extends FlatSpec {
+class CatalogServiceSpec extends AnyFlatSpec {
 
   "A dataset" should "default to using the ID as the title" in {
     val id = "id"

--- a/src/test/scala/latis/service/hapi/DataServiceSpec.scala
+++ b/src/test/scala/latis/service/hapi/DataServiceSpec.scala
@@ -30,7 +30,7 @@ class DataServiceSpec extends FlatSpec {
 
   /** Build a simple test DataService[IO] with a time -> int dataset using the Latis3Interpreter*/
   private lazy val dataset = (for {
-    time <- Time.fromMetadata(Metadata("id"->"time", "type"->"string", "size"->"24", "units"->"yyyy-MM-dd", "coverage"->"2000-01-01/2000-01-05"))
+    time <- Time.fromMetadata(Metadata("id"->"time", "type"->"string", "units"->"yyyy-MM-dd", "coverage"->"2000-01-01/2000-01-05"))
     disp <- Scalar.fromMetadata(Metadata("id"->"displacement", "type"->"int", "units"->"meters"))
     model <- Function.from(id"testfunc", time, disp)
     data = new SeqFunction(Seq(

--- a/src/test/scala/latis/service/hapi/DataServiceSpec.scala
+++ b/src/test/scala/latis/service/hapi/DataServiceSpec.scala
@@ -8,7 +8,7 @@ import io.circe.syntax._
 import org.http4s.{Status => _, _}
 import org.http4s.implicits._
 import org.scalatest.Assertion
-import org.scalatest.FlatSpec
+import org.scalatest.flatspec._
 import org.typelevel.ci.CIString
 import scodec.codecs
 
@@ -26,7 +26,7 @@ import latis.service.hapi.{Status => HStatus}
 import latis.time.Time
 import latis.util.Identifier.IdentifierStringContext
 
-class DataServiceSpec extends FlatSpec {
+class DataServiceSpec extends AnyFlatSpec {
 
   /** Build a simple test DataService[IO] with a time -> int dataset using the Latis3Interpreter*/
   private lazy val dataset = (for {

--- a/src/test/scala/latis/service/hapi/TimeSpec.scala
+++ b/src/test/scala/latis/service/hapi/TimeSpec.scala
@@ -4,9 +4,9 @@ import java.time.LocalDateTime
 
 import org.scalactic.Equality
 import org.scalatest.Assertion
-import org.scalatest.FlatSpec
+import org.scalatest.flatspec._
 
-class TimeSpec extends FlatSpec {
+class TimeSpec extends AnyFlatSpec {
 
   val expected = LocalDateTime.of(2018, 1, 1, 0, 0, 0)
 

--- a/src/test/scala/latis/service/hapi/ToHapiTimeSpec.scala
+++ b/src/test/scala/latis/service/hapi/ToHapiTimeSpec.scala
@@ -1,0 +1,164 @@
+package latis.service.hapi
+
+import cats.effect.unsafe.implicits.global
+import org.scalatest.EitherValues._
+import org.scalatest.FlatSpec
+
+import latis.data.DomainData
+import latis.data.RangeData
+import latis.data.Sample
+import latis.data.SeqFunction
+import latis.dataset.MemoizedDataset
+import latis.metadata.Metadata
+import latis.model._
+import latis.ops.ToHapiTime
+import latis.time.Time
+
+class ToHapiTimeSpec extends FlatSpec{
+
+  private lazy val toHapiTime = new ToHapiTime
+
+  "The ToHapiTime operation" should "expand yyyy-MM-dd" in {
+    val time = Time.fromMetadata(Metadata("id"->"time", "type"->"string", "units"->"yyyy-MM-dd", "coverage"->"2000-01-01/2000-01-02")).right.value
+    val disp = Scalar.fromMetadata(Metadata("id"->"displacement", "type"->"int", "units"->"meters")).right.value
+    val model = Function.from(time, disp).right.value
+    val data = new SeqFunction(Seq(
+      Sample(DomainData("2000-01-01"), RangeData(1)),
+    ))
+    val dataset = new MemoizedDataset(Metadata("id"->"d1"), model, data).withOperation(toHapiTime)
+    val metadata = dataset.model.getScalars.head.metadata
+    val size = metadata.getProperty("size").get
+    val units = metadata.getProperty("units").get
+    val timeVal = dataset.samples.map(t => t.domain.head.value).compile.toList.unsafeRunSync()
+
+    assert(size == "24")
+    assert(units == "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
+    assert(timeVal.head.toString == "2000-01-01T00:00:00.000Z")
+  }
+
+  it should "handle full length yyyy-MM-ddTHH:mm:ss.SSSZ" in {
+    val time = Time.fromMetadata(Metadata("id"->"time", "type"->"string", "units"->"yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", "coverage"->"2000-01-01T00:00:00.000Z/2000-01-02T00:00:00.000Z")).right.value
+    val disp = Scalar.fromMetadata(Metadata("id"->"displacement", "type"->"int", "units"->"meters")).right.value
+    val model = Function.from(time, disp).right.value
+    val data = new SeqFunction(Seq(
+      Sample(DomainData("2000-01-01T01:01:01.001Z"), RangeData(1)),
+    ))
+    val dataset = new MemoizedDataset(Metadata("id"->"d1"), model, data).withOperation(toHapiTime)
+    val metadata = dataset.model.getScalars.head.metadata
+    val size = metadata.getProperty("size").get
+    val units = metadata.getProperty("units").get
+    val timeVal = dataset.samples.map(t => t.domain.head.value).compile.toList.unsafeRunSync()
+
+    assert(size == "24")
+    assert(units == "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
+    assert(timeVal.head.toString == "2000-01-01T01:01:01.001Z")
+  }
+
+  it should "expand yyyy-ddd" in {
+    val time = Time.fromMetadata(Metadata("id"->"time", "type"->"string", "units"->"yyyy-ddd", "coverage"->"2000-001/2000-002")).right.value
+    val disp = Scalar.fromMetadata(Metadata("id"->"displacement", "type"->"int", "units"->"meters")).right.value
+    val model = Function.from(time, disp).right.value
+    val data = new SeqFunction(Seq(
+      Sample(DomainData("2000-001"), RangeData(1)),
+    ))
+    val dataset = new MemoizedDataset(Metadata("id"->"d1"), model, data).withOperation(toHapiTime)
+    val metadata = dataset.model.getScalars.head.metadata
+    val size = metadata.getProperty("size").get
+    val units = metadata.getProperty("units").get
+    val timeVal = dataset.samples.map(t => t.domain.head.value).compile.toList.unsafeRunSync()
+
+    assert(size == "24")
+    assert(units == "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
+    assert(timeVal.head.toString == "2000-01-01T00:00:00.000Z")
+  }
+
+  it should "handle full length yyyy-dddTHH:mm:ss.SSSZ" in {
+    val time = Time.fromMetadata(Metadata("id"->"time", "type"->"string", "units"->"yyyy-ddd'T'HH:mm:ss.SSS'Z'", "coverage"->"2000-001T00:00:00.000Z/2000-002T00:00:00.000Z")).right.value
+    val disp = Scalar.fromMetadata(Metadata("id"->"displacement", "type"->"int", "units"->"meters")).right.value
+    val model = Function.from(time, disp).right.value
+    val data = new SeqFunction(Seq(
+      Sample(DomainData("2000-001T01:01:01.001Z"), RangeData(1)),
+    ))
+    val dataset = new MemoizedDataset(Metadata("id"->"d1"), model, data).withOperation(toHapiTime)
+    val metadata = dataset.model.getScalars.head.metadata
+    val size = metadata.getProperty("size").get
+    val units = metadata.getProperty("units").get
+    val timeVal = dataset.samples.map(t => t.domain.head.value).compile.toList.unsafeRunSync()
+
+    assert(size == "24")
+    assert(units == "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
+    assert(timeVal.head.toString == "2000-01-01T01:01:01.001Z")
+  }
+
+  it should "handle time in seconds since 2000" in {
+    val time = Time.fromMetadata(Metadata("id"->"time", "type"->"double", "units"->"seconds since 2000-01-01", "coverage"->"0/10000")).right.value
+    val disp = Scalar.fromMetadata(Metadata("id"->"displacement", "type"->"int", "units"->"meters")).right.value
+    val model = Function.from(time, disp).right.value
+    val data = new SeqFunction(Seq(
+      Sample(time.convertValue("3661.001").toSeq, RangeData(1)),
+    ))
+    val dataset = new MemoizedDataset(Metadata("id"->"d1"), model, data).withOperation(toHapiTime)
+    val metadata = dataset.model.getScalars.head.metadata
+    val size = metadata.getProperty("size").get
+    val units = metadata.getProperty("units").get
+    val timeVal = dataset.samples.map(t => t.domain.head.value).compile.toList.unsafeRunSync()
+
+    assert(size == "24")
+    assert(units == "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
+    assert(timeVal.head.toString == "2000-01-01T01:01:01.001Z")
+  }
+
+  it should "handle time in milliseconds since 2000" in {
+    val time = Time.fromMetadata(Metadata("id"->"time", "type"->"double", "units"->"milliseconds since 2000-01-01", "coverage"->"0/10000000")).right.value
+    val disp = Scalar.fromMetadata(Metadata("id"->"displacement", "type"->"int", "units"->"meters")).right.value
+    val model = Function.from(time, disp).right.value
+    val data = new SeqFunction(Seq(
+      Sample(time.convertValue("3661001").toSeq, RangeData(1)),
+    ))
+    val dataset = new MemoizedDataset(Metadata("id"->"d1"), model, data).withOperation(toHapiTime)
+    val metadata = dataset.model.getScalars.head.metadata
+    val size = metadata.getProperty("size").get
+    val units = metadata.getProperty("units").get
+    val timeVal = dataset.samples.map(t => t.domain.head.value).compile.toList.unsafeRunSync()
+
+    assert(size == "24")
+    assert(units == "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
+    assert(timeVal.head.toString == "2000-01-01T01:01:01.001Z")
+  }
+
+  it should "handle time in seconds since 1970" in {
+    val time = Time.fromMetadata(Metadata("id"->"time", "type"->"double", "units"->"seconds since 1970-01-01", "coverage"->"0/1000000000")).right.value
+    val disp = Scalar.fromMetadata(Metadata("id"->"displacement", "type"->"int", "units"->"meters")).right.value
+    val model = Function.from(time, disp).right.value
+    val data = new SeqFunction(Seq(
+      Sample(time.convertValue("946688461.001").toSeq, RangeData(1)),
+    ))
+    val dataset = new MemoizedDataset(Metadata("id"->"d1"), model, data).withOperation(toHapiTime)
+    val metadata = dataset.model.getScalars.head.metadata
+    val size = metadata.getProperty("size").get
+    val units = metadata.getProperty("units").get
+    val timeVal = dataset.samples.map(t => t.domain.head.value).compile.toList.unsafeRunSync()
+
+    assert(size == "24")
+    assert(units == "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
+    assert(timeVal.head.toString == "2000-01-01T01:01:01.001Z")
+  }
+
+  it should "handle time in milliseconds since 1970" in {
+    val time = Time.fromMetadata(Metadata("id"->"time", "type"->"double", "units"->"milliseconds since 1970-01-01", "coverage"->"0/1000000000000")).right.value
+    val disp = Scalar.fromMetadata(Metadata("id"->"displacement", "type"->"int", "units"->"meters")).right.value
+    val model = Function.from(time, disp).right.value
+    val data = new SeqFunction(Seq(
+      Sample(time.convertValue("946688461001").toSeq, RangeData(1)),
+    ))
+    val dataset = new MemoizedDataset(Metadata("id"->"d1"), model, data).withOperation(toHapiTime)
+    val metadata = dataset.model.getScalars.head.metadata
+    val size = metadata.getProperty("size").get
+    val units = metadata.getProperty("units").get
+    val timeVal = dataset.samples.map(t => t.domain.head.value).compile.toList.unsafeRunSync()
+
+    assert(size == "24")
+    assert(units == "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
+    assert(timeVal.head.toString == "2000-01-01T01:01:01.001Z")
+  }
+}

--- a/src/test/scala/latis/service/hapi/ToHapiTimeSpec.scala
+++ b/src/test/scala/latis/service/hapi/ToHapiTimeSpec.scala
@@ -19,9 +19,9 @@ class ToHapiTimeSpec extends AnyFlatSpec{
   private lazy val toHapiTime = new ToHapiTime
 
   "The ToHapiTime operation" should "expand yyyy-MM-dd" in {
-    val time = Time.fromMetadata(Metadata("id"->"time", "type"->"string", "units"->"yyyy-MM-dd", "coverage"->"2000-01-01/2000-01-02")).right.value
-    val disp = Scalar.fromMetadata(Metadata("id"->"displacement", "type"->"int", "units"->"meters")).right.value
-    val model = Function.from(time, disp).right.value
+    val time = Time.fromMetadata(Metadata("id"->"time", "type"->"string", "units"->"yyyy-MM-dd", "coverage"->"2000-01-01/2000-01-02")).value
+    val disp = Scalar.fromMetadata(Metadata("id"->"displacement", "type"->"int", "units"->"meters")).value
+    val model = Function.from(time, disp).value
     val data = new SeqFunction(Seq(
       Sample(DomainData("2000-01-01"), RangeData(1)),
     ))
@@ -37,9 +37,9 @@ class ToHapiTimeSpec extends AnyFlatSpec{
   }
 
   it should "handle full length yyyy-MM-ddTHH:mm:ss.SSSZ" in {
-    val time = Time.fromMetadata(Metadata("id"->"time", "type"->"string", "units"->"yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", "coverage"->"2000-01-01T00:00:00.000Z/2000-01-02T00:00:00.000Z")).right.value
-    val disp = Scalar.fromMetadata(Metadata("id"->"displacement", "type"->"int", "units"->"meters")).right.value
-    val model = Function.from(time, disp).right.value
+    val time = Time.fromMetadata(Metadata("id"->"time", "type"->"string", "units"->"yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", "coverage"->"2000-01-01T00:00:00.000Z/2000-01-02T00:00:00.000Z")).value
+    val disp = Scalar.fromMetadata(Metadata("id"->"displacement", "type"->"int", "units"->"meters")).value
+    val model = Function.from(time, disp).value
     val data = new SeqFunction(Seq(
       Sample(DomainData("2000-01-01T01:01:01.001Z"), RangeData(1)),
     ))
@@ -55,9 +55,9 @@ class ToHapiTimeSpec extends AnyFlatSpec{
   }
 
   it should "expand yyyy-ddd" in {
-    val time = Time.fromMetadata(Metadata("id"->"time", "type"->"string", "units"->"yyyy-ddd", "coverage"->"2000-001/2000-002")).right.value
-    val disp = Scalar.fromMetadata(Metadata("id"->"displacement", "type"->"int", "units"->"meters")).right.value
-    val model = Function.from(time, disp).right.value
+    val time = Time.fromMetadata(Metadata("id"->"time", "type"->"string", "units"->"yyyy-ddd", "coverage"->"2000-001/2000-002")).value
+    val disp = Scalar.fromMetadata(Metadata("id"->"displacement", "type"->"int", "units"->"meters")).value
+    val model = Function.from(time, disp).value
     val data = new SeqFunction(Seq(
       Sample(DomainData("2000-001"), RangeData(1)),
     ))
@@ -73,9 +73,9 @@ class ToHapiTimeSpec extends AnyFlatSpec{
   }
 
   it should "handle full length yyyy-dddTHH:mm:ss.SSSZ" in {
-    val time = Time.fromMetadata(Metadata("id"->"time", "type"->"string", "units"->"yyyy-ddd'T'HH:mm:ss.SSS'Z'", "coverage"->"2000-001T00:00:00.000Z/2000-002T00:00:00.000Z")).right.value
-    val disp = Scalar.fromMetadata(Metadata("id"->"displacement", "type"->"int", "units"->"meters")).right.value
-    val model = Function.from(time, disp).right.value
+    val time = Time.fromMetadata(Metadata("id"->"time", "type"->"string", "units"->"yyyy-ddd'T'HH:mm:ss.SSS'Z'", "coverage"->"2000-001T00:00:00.000Z/2000-002T00:00:00.000Z")).value
+    val disp = Scalar.fromMetadata(Metadata("id"->"displacement", "type"->"int", "units"->"meters")).value
+    val model = Function.from(time, disp).value
     val data = new SeqFunction(Seq(
       Sample(DomainData("2000-001T01:01:01.001Z"), RangeData(1)),
     ))
@@ -91,9 +91,9 @@ class ToHapiTimeSpec extends AnyFlatSpec{
   }
 
   it should "handle time in seconds since 2000" in {
-    val time = Time.fromMetadata(Metadata("id"->"time", "type"->"double", "units"->"seconds since 2000-01-01", "coverage"->"0/10000")).right.value
-    val disp = Scalar.fromMetadata(Metadata("id"->"displacement", "type"->"int", "units"->"meters")).right.value
-    val model = Function.from(time, disp).right.value
+    val time = Time.fromMetadata(Metadata("id"->"time", "type"->"double", "units"->"seconds since 2000-01-01", "coverage"->"0/10000")).value
+    val disp = Scalar.fromMetadata(Metadata("id"->"displacement", "type"->"int", "units"->"meters")).value
+    val model = Function.from(time, disp).value
     val data = new SeqFunction(Seq(
       Sample(time.convertValue("3661.001").toSeq, RangeData(1)),
     ))
@@ -109,9 +109,9 @@ class ToHapiTimeSpec extends AnyFlatSpec{
   }
 
   it should "handle time in milliseconds since 2000" in {
-    val time = Time.fromMetadata(Metadata("id"->"time", "type"->"double", "units"->"milliseconds since 2000-01-01", "coverage"->"0/10000000")).right.value
-    val disp = Scalar.fromMetadata(Metadata("id"->"displacement", "type"->"int", "units"->"meters")).right.value
-    val model = Function.from(time, disp).right.value
+    val time = Time.fromMetadata(Metadata("id"->"time", "type"->"double", "units"->"milliseconds since 2000-01-01", "coverage"->"0/10000000")).value
+    val disp = Scalar.fromMetadata(Metadata("id"->"displacement", "type"->"int", "units"->"meters")).value
+    val model = Function.from(time, disp).value
     val data = new SeqFunction(Seq(
       Sample(time.convertValue("3661001").toSeq, RangeData(1)),
     ))
@@ -127,9 +127,9 @@ class ToHapiTimeSpec extends AnyFlatSpec{
   }
 
   it should "handle time in seconds since 1970" in {
-    val time = Time.fromMetadata(Metadata("id"->"time", "type"->"double", "units"->"seconds since 1970-01-01", "coverage"->"0/1000000000")).right.value
-    val disp = Scalar.fromMetadata(Metadata("id"->"displacement", "type"->"int", "units"->"meters")).right.value
-    val model = Function.from(time, disp).right.value
+    val time = Time.fromMetadata(Metadata("id"->"time", "type"->"double", "units"->"seconds since 1970-01-01", "coverage"->"0/1000000000")).value
+    val disp = Scalar.fromMetadata(Metadata("id"->"displacement", "type"->"int", "units"->"meters")).value
+    val model = Function.from(time, disp).value
     val data = new SeqFunction(Seq(
       Sample(time.convertValue("946688461.001").toSeq, RangeData(1)),
     ))
@@ -145,9 +145,9 @@ class ToHapiTimeSpec extends AnyFlatSpec{
   }
 
   it should "handle time in milliseconds since 1970" in {
-    val time = Time.fromMetadata(Metadata("id"->"time", "type"->"double", "units"->"milliseconds since 1970-01-01", "coverage"->"0/1000000000000")).right.value
-    val disp = Scalar.fromMetadata(Metadata("id"->"displacement", "type"->"int", "units"->"meters")).right.value
-    val model = Function.from(time, disp).right.value
+    val time = Time.fromMetadata(Metadata("id"->"time", "type"->"double", "units"->"milliseconds since 1970-01-01", "coverage"->"0/1000000000000")).value
+    val disp = Scalar.fromMetadata(Metadata("id"->"displacement", "type"->"int", "units"->"meters")).value
+    val model = Function.from(time, disp).value
     val data = new SeqFunction(Seq(
       Sample(time.convertValue("946688461001").toSeq, RangeData(1)),
     ))

--- a/src/test/scala/latis/service/hapi/ToHapiTimeSpec.scala
+++ b/src/test/scala/latis/service/hapi/ToHapiTimeSpec.scala
@@ -2,7 +2,7 @@ package latis.service.hapi
 
 import cats.effect.unsafe.implicits.global
 import org.scalatest.EitherValues._
-import org.scalatest.FlatSpec
+import org.scalatest.flatspec._
 
 import latis.data.DomainData
 import latis.data.RangeData
@@ -14,7 +14,7 @@ import latis.model._
 import latis.ops.ToHapiTime
 import latis.time.Time
 
-class ToHapiTimeSpec extends FlatSpec{
+class ToHapiTimeSpec extends AnyFlatSpec{
 
   private lazy val toHapiTime = new ToHapiTime
 


### PR DESCRIPTION
Moves the mandatory setting of the size metadata for Time(s) to ToHapiTime, with constant value 24 because that is the known size of the always-used format: "yyyy-mm-ddThh:mm:ss.sssZ"

This currently passes all existing tests, including my recent DataService tests that use a Time domain but now no longer use directly-set size metadata for it. I am conflicted on whether more tests are needed....