### PR TITLE
Hapi 77 Landing Page Catalog

### DIFF
--- a/src/main/scala/latis/service/hapi/HapiService.scala
+++ b/src/main/scala/latis/service/hapi/HapiService.scala
@@ -71,11 +71,11 @@ class HapiService(catalog: Catalog) extends ServiceInterface(catalog) {
     val interpreter = new Latis3Interpreter(filteredCatalog)
 
     val service = {
-      new LandingPageService[IO].service          <+>
-      new AboutService[IO].service                <+>
-      new CapabilitiesService[IO].service         <+>
-      new InfoService[IO](interpreter).service    <+>
-      new CatalogService[IO](interpreter).service <+>
+      new LandingPageService[IO](interpreter).service <+>
+      new AboutService[IO].service                    <+>
+      new CapabilitiesService[IO].service             <+>
+      new InfoService[IO](interpreter).service        <+>
+      new CatalogService[IO](interpreter).service     <+>
       new DataService[IO](interpreter).service
     }
 

--- a/src/main/scala/latis/service/hapi/LandingPageService.scala
+++ b/src/main/scala/latis/service/hapi/LandingPageService.scala
@@ -1,46 +1,77 @@
 package latis.service.hapi
 
 import cats.Monad
+import cats.syntax.all._
 import org.http4s.HttpRoutes
 import org.http4s.dsl.Http4sDsl
 import org.http4s.scalatags._
+import scalatags.Text
 import scalatags.Text.all._
 
 /** Implements the HAPI landing page. */
-class LandingPageService[F[_]: Monad] extends Http4sDsl[F] {
+class LandingPageService[F[_]: Monad](alg: CatalogAlgebra[F]) extends Http4sDsl[F] {
 
-  val landingPage =
-    html(
-      body(
-        h1("LASP HAPI Server"),
-        p("""This server supports the HAPI 3.0 specification for
-        |delivery of time series data. The server consists of the
-        |following 5 REST-like endpoints that will respond to HTTP GET
-        |requests:""".stripMargin.replaceAll("\n", " ")),
-        ul(
-          li(
-            a(href := "hapi/about")("about"),
-            " - information about the server"
-          ),
-          li(
-            a(href := "hapi/capabilities")("capabilities"),
-            " - list the output formats the server can emit"
-          ),
-          li(
-            a(href := "hapi/catalog")("catalog"),
-            " - list the datasets that are available"
-          ),
-          li(
-            a(href := "hapi/info")("info"),
-            " - describe a dataset"
-          ),
-          li(
-            a(href := "hapi/data")("data"),
-            " - stream content of a dataset"
-          )
+  val catalogTable: F[Text.TypedTag[String]] = for {
+    catalog <- alg.getCatalog
+    catalogEntries = catalog.foldLeft(frag()) { (acc, dataset) =>
+      frag(
+        acc,
+        tr(
+          td(dataset.id),
+          td(a(href := "hapi/info?dataset="+dataset.id)(dataset.title))
         )
       )
+    }
+  } yield {
+    table(
+      caption(b(i(u("Catalog")))),
+      tr(
+        th("id"),
+        th("title"),
+      ),
+      catalogEntries
     )
+  }
+
+  val landingPage: F[Text.TypedTag[String]] = {
+    for {
+      table <- catalogTable
+    } yield {
+      html(
+        body(
+          h1("LASP HAPI Server"),
+          p(
+            """This server supports the HAPI 3.0 specification for
+              |delivery of time series data. The server consists of the
+              |following 5 REST-like endpoints that will respond to HTTP GET
+              |requests:""".stripMargin.replaceAll(System.lineSeparator(), " ")),
+          ul(
+            li(
+              a(href := "hapi/about")("about"),
+              " - information about the server"
+            ),
+            li(
+              a(href := "hapi/capabilities")("capabilities"),
+              " - list the output formats the server can emit"
+            ),
+            li(
+              a(href := "hapi/catalog")("catalog"),
+              " - list the datasets that are available"
+            ),
+            li(
+              a(href := "hapi/info")("info"),
+              " - describe a dataset"
+            ),
+            li(
+              a(href := "hapi/data")("data"),
+              " - stream content of a dataset"
+            )
+          ),
+          table
+        )
+      )
+    }
+  }
 
   val service: HttpRoutes[F] =
     HttpRoutes.of[F] {

--- a/src/test/scala/latis/service/hapi/LandingPageServiceSpec.scala
+++ b/src/test/scala/latis/service/hapi/LandingPageServiceSpec.scala
@@ -1,0 +1,55 @@
+package latis.service.hapi
+
+import cats.effect.IO
+import cats.effect.unsafe.implicits.global
+import org.http4s
+import org.http4s.Method
+import org.http4s.Request
+import org.http4s.implicits.http4sLiteralsSyntax
+import org.scalatest.flatspec.AnyFlatSpec
+import org.typelevel.ci.CIStringSyntax
+
+import latis.catalog.Catalog
+import latis.dataset.MemoizedDataset
+import latis.metadata.Metadata
+
+class LandingPageServiceSpec extends AnyFlatSpec {
+  private lazy val dataset1 = new MemoizedDataset(Metadata("id"->"id1", "title"->"title1"), null, null)
+  private lazy val dataset2 = new MemoizedDataset(Metadata("id"->"id2", "title"->"title2"), null, null)
+  private lazy val latisInterp = new Latis3Interpreter(Catalog(dataset1, dataset2))
+  private lazy val landingPageService = new LandingPageService[IO](latisInterp)
+
+  "The Landing Page" should "create a non-zero length '200 OK' response" in {
+    val req = Request[IO](Method.GET, uri"/")
+    (for {
+      response <- landingPageService.service.orNotFound(req)
+    } yield {
+      assert(response.status == http4s.Status.Ok)
+      assert(response.headers.get(ci"Content-Length").get.head.value.toInt > 0)
+    }).unsafeRunSync()
+  }
+
+  it should "correctly generate the catalog table" in {
+    (for {
+      catalog <- landingPageService.catalogTable
+    } yield {
+      val expected =
+        """<table>
+          |<caption><b><i><u>Catalog</u></i></b></caption>
+          |<tr>
+          |<th>id</th>
+          |<th>title</th>
+          |</tr>
+          |<tr>
+          |<td>id1</td>
+          |<td><a href="hapi/info?dataset=id1">title1</a></td>
+          |</tr>
+          |<tr>
+          |<td>id2</td>
+          |<td><a href="hapi/info?dataset=id2">title2</a></td>
+          |</tr>
+          |</table>""".stripMargin.replaceAll(System.lineSeparator(), "")
+      assert(catalog.render == expected)
+    }).unsafeRunSync()
+  }
+}


### PR DESCRIPTION
Adds a table with the catalog of datasets to the landing page, with links to the relevant info requests. I am definitely open to making stylistic changes if desired.