### PR TITLE
Update HAPI Catalog Filter

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,8 @@ ThisBuild / scalaVersion := "2.13.8"
 
 val fs2DataVersion = "1.4.1"
 val http4sVersion = "0.23.14"
-val latisVersion = "a626466"
+val latisVersion = "fd8e35d"
+val latisHapiVersion = "9d1e6f9"
 
 lazy val root = (project in file("."))
   .settings(
@@ -13,10 +14,10 @@ lazy val root = (project in file("."))
       "com.github.latis-data.latis3" %% "latis3-service-interface" % latisVersion,
       "com.github.latis-data.latis3" %% "latis3-server"            % latisVersion,
       "com.github.latis-data.latis3" %% "dap2-service-interface"   % latisVersion,
-      "com.github.latis-data"         % "latis3-hapi"              % "1d52ef7",
+      "com.github.latis-data"         % "latis3-hapi"              % latisHapiVersion,
       "org.http4s"                   %% "http4s-dsl"               % http4sVersion % Provided,
       "org.http4s"                   %% "http4s-circe"             % http4sVersion,
-      "org.http4s"                   %% "http4s-scalatags"         % "0.23.11",
+      "org.http4s"                   %% "http4s-scalatags"         % "0.24.0",
       "org.scalameta"                %% "munit"                    % "0.7.29" % Test,
       "org.typelevel"                %% "munit-cats-effect-3"      % "1.0.7" % Test,
       "io.circe"                     %% "circe-generic"            % "0.14.2",

--- a/src/main/scala/latis/ops/ConvertHapiTypes.scala
+++ b/src/main/scala/latis/ops/ConvertHapiTypes.scala
@@ -1,0 +1,50 @@
+package latis.ops
+
+import cats.syntax.all._
+
+import latis.data._
+import latis.data.Data._
+import latis.model._
+import latis.util.LatisException
+
+/**
+ * Converts scalar values to be consistent with supported HAPI types.
+ *
+ * HAPI supports only double, int, and string types. This will convert
+ * some types that can safely be converted. Datasets with other types
+ * will be excluded from the Catalog by HapiService.filteredCatalog.
+ * This operation needs to be consistent with that filter.
+ *
+ * This is only needed for the binary output.
+ */
+class ConvertHapiTypes extends MapOperation {
+  //TODO: assumes non-nested functions or tuples
+
+  def mapFunction(model: DataType): Sample => Sample = {
+    // Note, domain can only be time and it is handled elsewhere
+    case Sample(d, r) => Sample(d, RangeData(r.map(convertValue)))
+  }
+
+  private def convertValue(data: Data): Data = data match {
+    case v: ShortValue => IntValue(v.value.toInt)
+    case v: FloatValue => DoubleValue(v.value.toDouble)
+    case _             => data //no-op, shouldn't get here due to catalog filter
+  }
+
+  def applyToModel(model: DataType): Either[LatisException, DataType] = model.map {
+    case s: Scalar => convertValueType(s)
+    case dt => dt
+  }.asRight
+
+  private def convertValueType(scalar: Scalar): Scalar = scalar.valueType match {
+    case FloatValueType =>
+      Scalar.fromMetadata(
+        scalar.metadata + ("type" -> "double")
+      ).fold(throw _, identity) //should not fail
+    case ShortValueType =>
+      Scalar.fromMetadata(
+        scalar.metadata + ("type" -> "int")
+      ).fold(throw _, identity) //should not fail
+    case _ => scalar //no-op, shouldn't get here due to catalog filter
+  }
+}

--- a/src/main/scala/latis/service/hapi/HapiService.scala
+++ b/src/main/scala/latis/service/hapi/HapiService.scala
@@ -41,7 +41,7 @@ class HapiService(catalog: Catalog) extends ServiceInterface(catalog) {
   // This checks that:
   // - The Dataset metadata has temporalCoverage
   // - The single domain variable is of type Time
-  // - Each scalar in the range has units and a supported type
+  // - Each scalar in the range has a supported type
   // - If the type of a scalar is string, its size is defined
   private val filteredCatalog: Catalog = {
     val covP:  Metadata => Boolean = _.getProperty("temporalCoverage").isDefined
@@ -53,17 +53,16 @@ class HapiService(catalog: Catalog) extends ServiceInterface(catalog) {
       case "short"  => true //may be converted to int by ConvertHapiTypes
       case _        => false
     }
-    val unitsP: Metadata => Boolean = _.getProperty("units").isDefined
 
     catalog.filter { ds =>
       covP(ds.metadata) &&
       (ds.model match {
         case Function(_: Time, range) =>
-          // Note: Time is guaranteed to have units and the value type
-          // does not matter since it will be converted via ToHapiTime.
+          // Note: The Time value type does not matter
+          // since it will be converted via ToHapiTime.
           range.getScalars.forall { s =>
             val md = s.metadata
-            typeP(md) && unitsP(md)
+            typeP(md)
           }
         case _ => false
       })

--- a/src/main/scala/latis/service/hapi/Latis3Interpreter.scala
+++ b/src/main/scala/latis/service/hapi/Latis3Interpreter.scala
@@ -14,8 +14,14 @@ import io.circe.Json
 import io.circe.JsonObject
 
 import latis.catalog.Catalog
+import latis.model.DoubleValueType
+import latis.model.FloatValueType
 import latis.model.Function
+import latis.model.IntValueType
 import latis.model.Scalar
+import latis.model.ShortValueType
+import latis.model.StringValueType
+import latis.model.ValueType
 import latis.ops.ConvertHapiTypes
 import latis.ops.Projection
 import latis.ops.Selection
@@ -159,23 +165,15 @@ class Latis3Interpreter(catalog: Catalog) extends HapiInterpreter[IO] {
     }
 
   private def getScalarMetadata(s: Scalar): Either[InfoError, Parameter] = for {
-    tyName <- Either.fromOption(
-      s.metadata.getProperty("type"),
-      MetadataError("Parameter missing metadata property 'type'")
-    )
-    ty     <- Either.fromOption(
-      toDataType(tyName),
+    ty <- Either.fromOption(
+      toDataType(s.valueType),
       MetadataError("Parameter has unsupported value for metadata property 'type'")
-    )
-    units  <- Either.fromOption(
-      s.metadata.getProperty("units"),
-      MetadataError("Parameter missing metadata property 'units'")
     )
   } yield Parameter(
     s.id.asString,
     ty,
     None,
-    units,
+    s.units,
     None,
     s.metadata.getProperty("missing_value"),
     s.metadata.getProperty("description"),
@@ -186,7 +184,7 @@ class Latis3Interpreter(catalog: Catalog) extends HapiInterpreter[IO] {
     "time",
     HIsoTime,
     Option(24),
-    "UTC",
+    "UTC".some,
     None,
     dt.metadata.getProperty("missing_value"),
     dt.metadata.getProperty("description"),

--- a/src/main/scala/latis/service/hapi/Parameter.scala
+++ b/src/main/scala/latis/service/hapi/Parameter.scala
@@ -20,7 +20,7 @@ final case class Parameter(
   name: String,
   dType: DataType,
   length: Option[Int],
-  units: String,
+  units: Option[String],
   size: Option[List[Int]],
   fill: Option[String],
   description: Option[String],
@@ -32,15 +32,16 @@ object Parameter {
   /**
    * JSON encoder
    *
-   * This encoder will drop parameters that are None except for fill,
-   * which is always required.
+   * This encoder will drop parameters that are None except for
+   * units and fill, which are always required.
    */
   implicit val encoder: Encoder[Parameter] =
     deriveEncoder[Parameter].mapJsonObject { obj =>
       JsonObject.fromIterable {
         obj.toList.filter {
-          case ("fill", _) => true
-          case (_, v)      => !v.isNull
+          case ("units", _) => true
+          case ("fill", _)  => true
+          case (_, v)       => !v.isNull
         }.map {
           case ("dType", v) => ("type", v)
           case x            => x


### PR DESCRIPTION
This updates what datasets make it into the HAPI catalog. The filter changes include:
- Look for `temporalCoverage` in the dataset metadata instead of using `coverage` from the time variable. The latter requires a precise definition to support index math (e.g. netCDF subsetting) while the former supports the nominal coverage required by HAPI.
- Support `short` and `float` types by converting them as needed for binary output. They should otherwise be fine for CSV and JSON output (rather than add noisy extra floating point precision). We can consider adding others as needed, though I opted for safe type conversions. Note that longs will not be supported in the *range* but times as longs will still be supported since they will get converted to ISO anyway.
- Remove requirement for `units` to be defined, defaulting to a JSON null when not defined.