### PR TITLE
Remove main logback config

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ ThisBuild / scalaVersion := "2.13.8"
 
 val fs2DataVersion = "1.5.0"
 val http4sVersion = "0.23.15"
-val latisVersion = "de6724b"
+val latisVersion = "49a8367"
 val latisHapiVersion = "55f5bb2"
 
 lazy val root = (project in file("."))
@@ -23,7 +23,7 @@ lazy val root = (project in file("."))
       "io.circe"                     %% "circe-generic"            % "0.14.2",
       // coursier only seems to include compile dependencies when
       // building a standalone executable (see coursier/coursier#552)
-      "ch.qos.logback"                % "logback-classic"          % "1.2.8",
+      "ch.qos.logback"                % "logback-classic"          % "1.3.1" % Test,
       "org.gnieh"                    %% "fs2-data-json"            % fs2DataVersion,
       "org.gnieh"                    %% "fs2-data-json-circe"      % fs2DataVersion
     ),

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -1,13 +1,11 @@
 <configuration>
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
-      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %X %msg%n</pattern>
     </encoder>
   </appender>
 
-  <logger name="org.http4s" level="INFO" />
-
-  <root level="DEBUG">
+  <root level="OFF">
     <appender-ref ref="STDOUT" />
   </root>
 </configuration>

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -1,11 +1,22 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE configuration>
+
 <configuration>
-  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-    <encoder>
-      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %X %msg%n</pattern>
+  <import class="ch.qos.logback.classic.encoder.PatternLayoutEncoder"/>
+  <import class="ch.qos.logback.core.ConsoleAppender"/>
+
+  <!-- Silence all logback status logs including warnings and errors. -->
+  <!--statusListener class="ch.qos.logback.core.status.NopStatusListener" /-->
+
+  <appender name="STDOUT" class="ConsoleAppender">
+    <encoder class="PatternLayoutEncoder">
+      <pattern>
+        [%d{yyyy-MM-dd'T'HH:mm:ss.SSS, GMT} %-5level %logger{36} \(%thread\) \(%X\)] %msg%n
+      </pattern>
     </encoder>
   </appender>
 
   <root level="OFF">
-    <appender-ref ref="STDOUT" />
+    <appender-ref ref="STDOUT"/>
   </root>
 </configuration>


### PR DESCRIPTION
Server projects that depend on this otherwise risk loading the wrong log configuration. This preserves the ability to manage/silence logs during testing.